### PR TITLE
The defhelper macro should expose the arglist as the standard :arglist metadata 

### DIFF
--- a/src/honeysql/helpers.clj
+++ b/src/honeysql/helpers.clj
@@ -10,11 +10,14 @@
   (let [kw (keyword (name helper))]
     `(do
        (defmethod build-clause ~kw ~(into ['_] arglist) ~@more)
-       (defn ~helper [& args#]
-         (let [[m# args#] (if (map? (first args#))
-                            [(first args#) (rest args#)]
-                            [{} args#])]
-           (build-clause ~kw m# args#))))))
+       (doto (defn ~helper [& args#]
+               (let [[m# args#] (if (map? (first args#))
+                                  [(first args#) (rest args#)]
+                                  [{} args#])]
+                 (build-clause ~kw m# args#)))
+         ;; maintain the original arglist instead of getting
+         ;; ([& args__6880__auto__])
+         (alter-meta! assoc :arglists '(~arglist))))))
 
 (defn collify [x]
   (if (coll? x) x [x]))


### PR DESCRIPTION
This should hopefully make documentation via clojure.repl/doc and
others a bit more readable.
