### PR TITLE
Added DELETE clause that takes a FROM clause

### DIFF
--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -156,7 +156,7 @@
 
 (def clause-order
   "Determines the order that clauses will be placed within generated SQL"
-  [:select :insert-into :update :delete-from :columns :set :from :join
+  [:select :insert-into :update :delete :delete-from :columns :set :from :join
    :left-join :right-join :where :group-by :having :order-by :limit :offset
    :values :query-values])
 
@@ -386,3 +386,6 @@
 
 (defmethod format-clause :delete-from [[_ table] _]
   (str "DELETE FROM " (to-sql table)))
+
+(defmethod format-clause :delete [[_ table] _]
+  (str "DELETE " (to-sql table)))

--- a/src/honeysql/helpers.clj
+++ b/src/honeysql/helpers.clj
@@ -209,3 +209,10 @@
 (defn delete-from
   ([table] (delete-from nil table))
   ([m table] (build-clause :delete-from m table)))
+
+(defmethod build-clause :delete [_ m table]
+  (assoc m :delete table))
+
+(defn delete
+  ([table] (delete nil table))
+  ([m table] (build-clause :delete m table)))


### PR DESCRIPTION
This makes T-SQL join deletes and MYSQL multi deletes possible.
```SQL
DELETE t1,t2 
FROM table1 AS t1 
INNER JOIN table2 t2 ...
INNER JOIN table3 t3 ...
```
`update` syntax can be used like this in standard HoneySQL, but `:delete-from` only accepts one table. A separate `delete` that takes a `from` clause mirrors `update`s existing flexibility in this.