### PR TITLE
Support basic common table expressions.

### DIFF
--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -156,7 +156,7 @@
 
 (def clause-order
   "Determines the order that clauses will be placed within generated SQL"
-  [:with :select :insert-into :update :delete-from :columns :set :from :join
+  [:with :with-recursive :select :insert-into :update :delete-from :columns :set :from :join
    :left-join :right-join :where :group-by :having :order-by :limit :offset
    :values :query-values])
 
@@ -393,3 +393,12 @@
 
 (defmethod format-clause :with [[_ ctes] _]
   (str "WITH " (comma-join (map cte->sql ctes))))
+
+(defmethod format-clause :with-recursive [[_ ctes] _]
+  (str "WITH RECURSIVE " (comma-join (map cte->sql ctes))))
+
+(defmethod fmt/format-clause :union [[_ maps] _]
+  (string/join " UNION " (map fmt/to-sql maps)))
+
+(defmethod fmt/format-clause :union-all [[_ maps] _]
+  (string/join " UNION ALL " (map fmt/to-sql maps)))

--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -397,8 +397,8 @@
 (defmethod format-clause :with-recursive [[_ ctes] _]
   (str "WITH RECURSIVE " (comma-join (map cte->sql ctes))))
 
-(defmethod fmt/format-clause :union [[_ maps] _]
-  (string/join " UNION " (map fmt/to-sql maps)))
+(defmethod format-clause :union [[_ maps] _]
+  (string/join " UNION " (map to-sql maps)))
 
-(defmethod fmt/format-clause :union-all [[_ maps] _]
-  (string/join " UNION ALL " (map fmt/to-sql maps)))
+(defmethod format-clause :union-all [[_ maps] _]
+  (string/join " UNION ALL " (map to-sql maps)))

--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -156,7 +156,7 @@
 
 (def clause-order
   "Determines the order that clauses will be placed within generated SQL"
-  [:select :insert-into :update :delete-from :columns :set :from :join
+  [:with :select :insert-into :update :delete-from :columns :set :from :join
    :left-join :right-join :where :group-by :having :order-by :limit :offset
    :values :query-values])
 
@@ -386,3 +386,10 @@
 
 (defmethod format-clause :delete-from [[_ table] _]
   (str "DELETE FROM " (to-sql table)))
+  
+(defn cte->sql
+  [[cte-name query]]
+  (str (to-sql cte-name) " AS " (to-sql query)))
+
+(defmethod format-clause :with [[_ ctes] _]
+  (str "WITH " (comma-join (map cte->sql ctes))))

--- a/src/honeysql/helpers.clj
+++ b/src/honeysql/helpers.clj
@@ -215,3 +215,12 @@
   
 (defmethod build-clause :with [_ m ctes]
   (assoc m :with ctes))
+
+(defmethod build-clause :with-recursive [_ m ctes]
+  (assoc m :with-recursive ctes))
+
+(defmethod build-clause :union [_ m maps]
+  (assoc m :union maps))
+
+(defmethod build-clause :union-all [_ m maps]
+  (assoc m :union-all maps))

--- a/src/honeysql/helpers.clj
+++ b/src/honeysql/helpers.clj
@@ -212,3 +212,6 @@
 (defn delete-from
   ([table] (delete-from nil table))
   ([m table] (build-clause :delete-from m table)))
+  
+(defmethod build-clause :with [_ m ctes]
+  (assoc m :with ctes))


### PR DESCRIPTION
Note that this requires modifying the clause-order, thus users cannot use the built in extensibility alone to support CTEs.