### PR TITLE
support postgres-native parameters

### DIFF
--- a/test/honeysql/core_test.clj
+++ b/test/honeysql/core_test.clj
@@ -54,4 +54,8 @@
              ["SELECT DISTINCT f.*, b.baz, c.quux, b.bla AS bla_bla, now(), @x := 10 FROM foo f, baz b INNER JOIN draq ON f.b = draq.x LEFT JOIN clod c ON f.a = c.d RIGHT JOIN bock ON bock.z = c.e WHERE ((f.a = ? AND b.baz <> ?) OR (1 < 2 AND 2 < 3) OR (f.e in (1, ?, 3)) OR f.e BETWEEN 10 AND 20) GROUP BY f.a HAVING 0 < f.e ORDER BY b.baz DESC, c.quux LIMIT 50 OFFSET 10 "
               "bort" "gabba" 2])))
     (testing "SQL data prints and reads correctly"
-      (is (= m1 (read-string (pr-str m1)))))))
+      (is (= m1 (read-string (pr-str m1)))))
+    (testing "SQL data formats correctly with alternate param naming"
+      (is (= (sql/format m1 :params {:param1 "gabba" :param2 2} :parameterizer :postgresql)
+             ["SELECT DISTINCT f.*, b.baz, c.quux, b.bla AS bla_bla, now(), @x := 10 FROM foo f, baz b INNER JOIN draq ON f.b = draq.x LEFT JOIN clod c ON f.a = c.d RIGHT JOIN bock ON bock.z = c.e WHERE ((f.a = $1 AND b.baz <> $2) OR (1 < 2 AND 2 < 3) OR (f.e in (1, $3, 3)) OR f.e BETWEEN 10 AND 20) GROUP BY f.a HAVING 0 < f.e ORDER BY b.baz DESC, c.quux LIMIT 50 OFFSET 10 "
+              "bort" "gabba" 2])))))


### PR DESCRIPTION
It would be nice to use alternative ways of creating parameters; specifically, I have in mind Postgres, which uses `$1`, `$2`, etc instead of `?`, `?`, etc. (See [here](http://www.postgresql.org/docs/9.4/static/xfunc-sql.html)). This is useful when using HoneySQL in conjunction with a non-JDBC driver, such as [this one](https://github.com/alaisi/postgres.async). Anyway, this patch allows the user to specify that they want Postgres-native parameters:

```cljs
(sql/format :params {:foo "bar"} :parameterizer :postgresql)
```