### PR TITLE
memoize sqlable?

### DIFF
--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -260,11 +260,19 @@
   nil
   (-to-sql [x] "NULL"))
 
+(def class-cache (atom nil))
+
 (defn sqlable? [x]
-  (satisfies? ToSql x))
+  (let [c (class x)
+        cache @class-cache]
+    (if (contains? cache c)
+      (cache c)
+      (let [result (satisfies? ToSql x)]
+        (swap! class-cache assoc c result)
+        result))))
 
 (defn to-sql [x]
-  (if (satisfies? ToSql x)
+  (if (sqlable? x)
     (-to-sql x)
     (let [[x pname] (if (instance? SqlParam x)
                       (let [pname (param-name x)]


### PR DESCRIPTION
In simple benchmarks, calls to sql/format spend the majority of their time in satisfies. Make the simple cases simpler with caching.