### PR TITLE
upgrade clojure dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,4 +2,4 @@
   :description "SQL as Clojure data structures"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]])
+  :dependencies [[org.clojure/clojure "1.6.0"]])


### PR DESCRIPTION
Only really affects tests, but still, 1.6.0 is the release