### PR TITLE
Simplify type implementations using defrecord

### DIFF
--- a/src/honeysql/types.clj
+++ b/src/honeysql/types.clj
@@ -1,21 +1,11 @@
 (ns honeysql.types)
 
-(deftype SqlCall [name args _meta]
-  Object
-  (hashCode [this] (hash-combine (hash name) (hash args)))
-  (equals [this x]
-    (cond (identical? this x) true
-          (instance? SqlCall x) (and (= (.name this) (.name x))
-                                     (= (.args this) (.args x)))
-          :else false))
-  clojure.lang.IObj
-  (meta [this] _meta)
-  (withMeta [this m] (SqlCall. (.name this) (.args this) m)))
+(defrecord SqlCall [name args])
 
 (defn call
   "Represents a SQL function call. Name should be a keyword."
   [name & args]
-  (SqlCall. name args nil))
+  (SqlCall. name args))
 
 (defn read-sql-call [form]
   (apply call form))
@@ -28,18 +18,12 @@
 
 ;;;;
 
-(deftype SqlRaw [s _meta]
-  Object
-  (hashCode [this] (hash-combine (hash (class this)) (hash s)))
-  (equals [this x] (and (instance? SqlRaw x) (= (.s this) (.s x))))
-  clojure.lang.IObj
-  (meta [this] _meta)
-  (withMeta [this m] (SqlRaw. (.s this) m)))
+(defrecord SqlRaw [s])
 
 (defn raw
   "Represents a raw SQL string"
   [s]
-  (SqlRaw. (str s) nil))
+  (SqlRaw. (str s)))
 
 (defn read-sql-raw [form]
   (raw form))
@@ -52,18 +36,12 @@
 
 ;;;;
 
-(deftype SqlParam [name _meta]
-  Object
-  (hashCode [this] (hash-combine (hash (class this)) (hash (name name))))
-  (equals [this x] (and (instance? SqlParam x) (= (.name this) (.name x))))
-  clojure.lang.IObj
-  (meta [this] _meta)
-  (withMeta [this m] (SqlParam. (.name this) m)))
+(defrecord SqlParam [name])
 
 (defn param
   "Represents a SQL parameter which can be filled in later"
   [name]
-  (SqlParam. name nil))
+  (SqlParam. name))
 
 (defn param-name [^SqlParam param]
   (.name param))

--- a/src/honeysql/types.clj
+++ b/src/honeysql/types.clj
@@ -7,15 +7,6 @@
   [name & args]
   (SqlCall. name args))
 
-(defn read-sql-call [form]
-  (apply call form))
-
-(defmethod print-method SqlCall [^SqlCall o ^java.io.Writer w]
-  (.write w (str "#sql/call " (pr-str (into [(.name o)] (.args o))))))
-
-(defmethod print-dup SqlCall [o w]
-  (print-method o w))
-
 ;;;;
 
 (defrecord SqlRaw [s])
@@ -24,15 +15,6 @@
   "Represents a raw SQL string"
   [s]
   (SqlRaw. (str s)))
-
-(defn read-sql-raw [form]
-  (raw form))
-
-(defmethod print-method SqlRaw [^SqlRaw o ^java.io.Writer w]
-  (.write w (str "#sql/raw " (pr-str (.s o)))))
-
-(defmethod print-dup SqlRaw [o w]
-  (print-method o w))
 
 ;;;;
 
@@ -46,11 +28,15 @@
 (defn param-name [^SqlParam param]
   (.name param))
 
+;;;;
+
+;; retain readers for backwards compatibility
+
+(defn read-sql-call [form]
+  (apply call form))
+
+(defn read-sql-raw [form]
+  (raw form))
+
 (defn read-sql-param [form]
   (param form))
-
-(defmethod print-method SqlParam [^SqlParam o ^java.io.Writer w]
-  (.write w (str "#sql/param " (pr-str (.name o)))))
-
-(defmethod print-dup SqlParam [o w]
-  (print-method o w))


### PR DESCRIPTION
This removes a decent amout of boilerplate from honeysql.types by using defrecord. In particular, it removes the need for custom printing methods.

I'll be honest, my motivation for working on this change is a bit esoteric -- in my vim sessions I have C-t bound to clojure.tools.namespace.repl/refresh and clojure.test/run-all-tests. The trouble is that refresh recreates the types in honeysql.types and this winds up breaking the round-trip printing test (in particular, the problem is the custom readers -- they wind up bound to the un-reloaded versions of the reader functions which are bound to the old types). Using default print/read for records fixes this for me.

I've left in the old read methods for backwards compatibility.