### PR TITLE
in unit test, put expected value first

### DIFF
--- a/test/honeysql/core_test.clj
+++ b/test/honeysql/core_test.clj
@@ -50,8 +50,8 @@
     (testing "Various construction methods are consistent"
       (is (= m1 m3)))
     (testing "SQL data formats correctly"
-      (is (= (sql/format m1 {:param1 "gabba" :param2 2})
-             ["SELECT DISTINCT f.*, b.baz, c.quux, b.bla AS bla_bla, now(), @x := 10 FROM foo f, baz b INNER JOIN draq ON f.b = draq.x LEFT JOIN clod c ON f.a = c.d RIGHT JOIN bock ON bock.z = c.e WHERE ((f.a = ? AND b.baz <> ?) OR (1 < 2 AND 2 < 3) OR (f.e in (1, ?, 3)) OR f.e BETWEEN 10 AND 20) GROUP BY f.a HAVING 0 < f.e ORDER BY b.baz DESC, c.quux LIMIT 50 OFFSET 10 "
-              "bort" "gabba" 2])))
+      (is (= ["SELECT DISTINCT f.*, b.baz, c.quux, b.bla AS bla_bla, now(), @x := 10 FROM foo f, baz b INNER JOIN draq ON f.b = draq.x LEFT JOIN clod c ON f.a = c.d RIGHT JOIN bock ON bock.z = c.e WHERE ((f.a = ? AND b.baz <> ?) OR (1 < 2 AND 2 < 3) OR (f.e in (1, ?, 3)) OR f.e BETWEEN 10 AND 20) GROUP BY f.a HAVING 0 < f.e ORDER BY b.baz DESC, c.quux LIMIT 50 OFFSET 10 "
+              "bort" "gabba" 2]
+             (sql/format m1 {:param1 "gabba" :param2 2}))))
     (testing "SQL data prints and reads correctly"
       (is (= m1 (read-string (pr-str m1)))))))


### PR DESCRIPTION
is assumes that the first argument to = is a fixture, and the second is
the result of a computation, when it prints Expected: and Actual: