### PR TITLE
Supporting extended INSERT INTO...SELECT syntax

### DIFF
--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -46,6 +46,7 @@
 
 (defn- undasherize [s]
   (string/replace s "-" "_"))
+
 (defn quote-identifier [x & {:keys [style split] :or {split true}}]
   (let [qf (if style
              (quote-fns style)
@@ -369,7 +370,12 @@
   (str "OFFSET " (to-sql offset)))
 
 (defmethod format-clause :insert-into [[_ table] _]
-  (str "INSERT INTO " (to-sql table)))
+  (if (and (sequential? table) (sequential? (first table)))
+    (str "INSERT INTO "
+         (to-sql (ffirst table))
+         " (" (comma-join (map to-sql (second (first table)))) ") "
+         (to-sql (second table)))
+    (str "INSERT INTO " (to-sql table))))
 
 (defmethod format-clause :columns [[_ fields] _]
   (str "(" (comma-join (map to-sql fields)) ")"))

--- a/test/honeysql/format_test.clj
+++ b/test/honeysql/format_test.clj
@@ -17,3 +17,11 @@
     'foo "foo"
     :foo-bar "foo_bar")
   (is (= (quote-identifier "*" :style :ansi) "*")))
+
+(deftest insert-into
+  (is (= (format-clause (first {:insert-into :foo}) nil)
+         "INSERT INTO foo"))
+  (is (= (format-clause (first {:insert-into [:foo {:select [:bar] :from [:baz]}]}) nil)
+         "INSERT INTO foo SELECT bar FROM baz"))
+  (is (= (format-clause (first {:insert-into [[:foo [:a :b :c]] {:select [:d :e :f] :from [:baz]}]}) nil)
+         "INSERT INTO foo (a, b, c) SELECT d, e, f FROM baz")))


### PR DESCRIPTION
I propose supporting insert queries in the form of

```sql
INSERT INTO foo (a, b, c) SELECT d, e, f FROM baz
```

...using the format:

```clojure
{:insert-into [[:foo [:a :b :c]] {:select [:d :e :f] :from [:baz]}]}
```

So, for example you could do:

```clojure
(hsql/format
  (hsql/build :insert-into [[:foo [:a :b :c]]
                            (hsql/build :select [:d :e :f] :from :baz)]))

;; ["INSERT INTO foo (a, b, c) (SELECT d, e, f FROM baz)"]
```

This is an extension to the insert-into method already available.  This would address #33.