### PR TITLE
use StringBuilder, not concatenation

### DIFF
--- a/test/honeysql/format_test.clj
+++ b/test/honeysql/format_test.clj
@@ -3,33 +3,42 @@
   (:require [clojure.test :refer [deftest testing is are]]
             [honeysql.format :refer :all]))
 
+(defmacro with-builder [& forms]
+  `(binding [*builder* (StringBuilder.)]
+     ~@forms
+     (str *builder*)))
+
 (deftest test-quote
   (are
     [qx res]
-    (= (apply quote-identifier "foo.bar.baz" qx) res)
+    (= (with-builder (apply quote-identifier "foo.bar.baz" qx)) res)
     [] "foo.bar.baz"
     [:style :mysql] "`foo`.`bar`.`baz`"
     [:style :mysql :split false] "`foo.bar.baz`")
   (are
     [x res]
-    (= (quote-identifier x) res)
+    (= (with-builder (quote-identifier x)) res)
     3 "3"
     'foo "foo"
     :foo-bar "foo_bar")
-  (is (= (quote-identifier "*" :style :ansi) "*")))
+  (is (= (with-builder (quote-identifier "*" :style :ansi)) "*")))
+
+(defn make-clause [& args]
+  (with-builder
+    (apply format-clause args)))
 
 (deftest test-cte
-  (is (= (format-clause
+  (is (= (make-clause
           (first {:with [[:query {:select [:foo] :from [:bar]}]]}) nil)
          "WITH query AS SELECT foo FROM bar"))
-  (is (= (format-clause
+  (is (= (make-clause
           (first {:with-recursive [[:query {:select [:foo] :from [:bar]}]]}) nil)
          "WITH RECURSIVE query AS SELECT foo FROM bar")))
 
 (deftest insert-into
-  (is (= (format-clause (first {:insert-into :foo}) nil)
+  (is (= (make-clause (first {:insert-into :foo}) nil)
          "INSERT INTO foo"))
-  (is (= (format-clause (first {:insert-into [:foo {:select [:bar] :from [:baz]}]}) nil)
+  (is (= (make-clause (first {:insert-into [:foo {:select [:bar] :from [:baz]}]}) nil)
          "INSERT INTO foo SELECT bar FROM baz"))
-  (is (= (format-clause (first {:insert-into [[:foo [:a :b :c]] {:select [:d :e :f] :from [:baz]}]}) nil)
+  (is (= (make-clause (first {:insert-into [[:foo [:a :b :c]] {:select [:d :e :f] :from [:baz]}]}) nil)
          "INSERT INTO foo (a, b, c) SELECT d, e, f FROM baz")))


### PR DESCRIPTION
Don't merge this just yet, it's definitely an experiment.

Wanted to see what would happen if we tried to use a single StringBuilder for formatting sql instead of repeatedly concatenating strings. What happens is the code gets pretty gnarly, honestly. I'd say we *probably* shouldn't merge this unless we have actual speed complaints from users. Query formatting does get faster (85 microseconds -> 75 microseconds) on the map in the unit tests. I imagine we'd see more substantial gains on queries with lots of nested function calls.