### PR TITLE
Provide a wrapper to prevent maps/vectors from being read as subqueries

### DIFF
--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -314,16 +314,17 @@
         sql-str)))
   nil
   (-to-sql [x] "NULL")
+  SqlParam
+  (-to-seql [x]
+    (let [pname (param-name x)]
+      (if (map? @*input-params*)
+        (add-param pname (get @*input-params* pname))
+        (let [x (first @*input-params*)]
+          (swap! *input-params* rest)
+          (add-param pname x)))))
   Object
   (-to-sql [x]
-    (if (instance? SqlParam x)
-      (let [pname (param-name x)]
-        (if (map? @*input-params*)
-          (add-param pname (get @*input-params* pname))
-          (let [x (first @*input-params*)]
-            (swap! *input-params* rest)
-            (add-param pname x))))
-      (add-anon-param x))))
+    (add-anon-param x)))
 
 (defn sqlable? [x]
   (satisfies? ToSql x))

--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -261,6 +261,13 @@
 (defprotocol ToSql
   (-to-sql [x]))
 
+(defrecord Value [v]
+  ToSql
+  (-to-sql [_]
+    (add-anon-param v)))
+
+(defn value [x] (Value. x))
+
 (declare -format-clause)
 
 (extend-protocol ToSql
@@ -315,7 +322,7 @@
   nil
   (-to-sql [x] "NULL")
   SqlParam
-  (-to-seql [x]
+  (-to-sql [x]
     (let [pname (param-name x)]
       (if (map? @*input-params*)
         (add-param pname (get @*input-params* pname))

--- a/test/honeysql/core_test.clj
+++ b/test/honeysql/core_test.clj
@@ -67,3 +67,11 @@
          (sql/format {:select [:foo (sql/call :cast :bar :integer)]})))
   (is (= ["SELECT foo, CAST(bar AS integer)"]
          (sql/format {:select [:foo (sql/call :cast :bar 'integer)]}))))
+
+(deftest test-value
+  (is (= ["INSERT INTO foo (bar) VALUES (?)" {:baz "my-val"}]
+         (->
+           (insert-into :foo)
+           (columns :bar)
+           (values [[(honeysql.format/value {:baz "my-val"})]])
+           sql/format))))


### PR DESCRIPTION
alternative to #64 attempts to solve #63 

Is value the best name? ```raw-value```? ```not-a-query-no-really```? something else?