### PR TITLE
NULL order specification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Here's a big, complicated query. Note that Honey SQL makes no attempt to verify 
              [:between :f.e 10 20]]
     :group-by [:f.a]
     :having [:< 0 :f.e]
-    :order-by [[:b.baz :desc] :c.quux]
+    :order-by [[:b.baz :desc] :c.quux [:f.a :nulls-first]
     :limit 50
     :offset 10}
 
@@ -265,7 +265,7 @@ Here's a big, complicated query. Note that Honey SQL makes no attempt to verify 
            OR f.e BETWEEN 10 AND 20)
      GROUP BY f.a
      HAVING 0 < f.e
-     ORDER BY b.baz DESC, c.quux
+     ORDER BY b.baz DESC, c.quux, f.a NULLS FIRST
      LIMIT 50
      OFFSET 10 "
      "bort" "gabba" 2]

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Here's a big, complicated query. Note that Honey SQL makes no attempt to verify 
              [:between :f.e 10 20]])
     (group :f.a)
     (having [:< 0 :f.e])
-    (order-by [:b.baz :desc] :c.quux)
+    (order-by [:b.baz :desc] :c.quux [:f.a :nulls-first])
     (limit 50)
     (offset 10))
 => {:select [:f.* :b.baz :c.quux [:b.bla "bla-bla"]

--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -412,15 +412,16 @@
   (str "ORDER BY "
        (comma-join (for [field fields]
                      (if (sequential? field)
-                       (let [[field order & [nulls-order]] field]
-                         ;; Correct way of handling this would be to
-                         ;; expect a dictionary with either order,
-                         ;; nulls order or both at the same
-                         ;; time. However, so far I'm not sure how to
-                         ;; achieve that, so first iteration will have
-                         ;; to use dirty hacks.
-                         (str (to-sql field) " " (if (= :desc order)
-                                                   "DESC" "ASC")))
+                       (let [[field & modifiers] field]
+                         (string/join " "
+                                      (cons (to-sql field)
+                                            (for [modifier modifiers]
+                                              (case modifier
+                                                :desc "DESC"
+                                                :asc "ASC"
+                                                :nulls-first "NULLS FIRST"
+                                                :nulls-last "NULLS LAST"
+                                                "")))))
                        (to-sql field))))))
 
 (defmethod format-clause :limit [[_ limit] _]

--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -412,7 +412,7 @@
   (str "ORDER BY "
        (comma-join (for [field fields]
                      (if (sequential? field)
-                       (let [[field order] field]
+                       (let [[field order & [nulls-order]] field]
                          (str (to-sql field) " " (if (= :desc order)
                                                    "DESC" "ASC")))
                        (to-sql field))))))

--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -413,6 +413,12 @@
        (comma-join (for [field fields]
                      (if (sequential? field)
                        (let [[field order & [nulls-order]] field]
+                         ;; Correct way of handling this would be to
+                         ;; expect a dictionary with either order,
+                         ;; nulls order or both at the same
+                         ;; time. However, so far I'm not sure how to
+                         ;; achieve that, so first iteration will have
+                         ;; to use dirty hacks.
                          (str (to-sql field) " " (if (= :desc order)
                                                    "DESC" "ASC")))
                        (to-sql field))))))

--- a/test/honeysql/core_test.clj
+++ b/test/honeysql/core_test.clj
@@ -24,7 +24,7 @@
                ;;(merge-where [:not= nil :b.bla])
                (group :f.a)
                (having [:< 0 :f.e])
-               (order-by [:b.baz :desc] :c.quux)
+               (order-by [:b.baz :desc] :c.quux [:f.a :nulls-first])
                (limit 50)
                (offset 10))
         m2 {:select [:f.* :b.baz :c.quux [:b.bla :bla-bla]
@@ -44,7 +44,7 @@
             ;;:merge-where [:not= nil :b.bla]
             :group-by :f.a
             :having [:< 0 :f.e]
-            :order-by [[:b.baz :desc] :c.quux]
+            :order-by [[:b.baz :desc] :c.quux [:f.a :nulls-first]]
             :limit 50
             :offset 10}
         m3 (sql/build m2)
@@ -52,14 +52,14 @@
     (testing "Various construction methods are consistent"
       (is (= m1 m3 m4)))
     (testing "SQL data formats correctly"
-      (is (= ["SELECT DISTINCT f.*, b.baz, c.quux, b.bla AS bla_bla, now(), @x := 10 FROM foo f, baz b INNER JOIN draq ON f.b = draq.x LEFT JOIN clod c ON f.a = c.d RIGHT JOIN bock ON bock.z = c.e FULL JOIN beck ON beck.x = c.y WHERE ((f.a = ? AND b.baz <> ?) OR (1 < 2 AND 2 < 3) OR (f.e in (1, ?, 3)) OR f.e BETWEEN 10 AND 20) GROUP BY f.a HAVING 0 < f.e ORDER BY b.baz DESC, c.quux LIMIT 50 OFFSET 10 "
+      (is (= ["SELECT DISTINCT f.*, b.baz, c.quux, b.bla AS bla_bla, now(), @x := 10 FROM foo f, baz b INNER JOIN draq ON f.b = draq.x LEFT JOIN clod c ON f.a = c.d RIGHT JOIN bock ON bock.z = c.e FULL JOIN beck ON beck.x = c.y WHERE ((f.a = ? AND b.baz <> ?) OR (1 < 2 AND 2 < 3) OR (f.e in (1, ?, 3)) OR f.e BETWEEN 10 AND 20) GROUP BY f.a HAVING 0 < f.e ORDER BY b.baz DESC, c.quux, f.a NULLS FIRST LIMIT 50 OFFSET 10 "
               "bort" "gabba" 2]
              (sql/format m1 {:param1 "gabba" :param2 2}))))
     (testing "SQL data prints and reads correctly"
       (is (= m1 (read-string (pr-str m1)))))
     (testing "SQL data formats correctly with alternate param naming"
       (is (= (sql/format m1 :params {:param1 "gabba" :param2 2} :parameterizer :postgresql)
-             ["SELECT DISTINCT f.*, b.baz, c.quux, b.bla AS bla_bla, now(), @x := 10 FROM foo f, baz b INNER JOIN draq ON f.b = draq.x LEFT JOIN clod c ON f.a = c.d RIGHT JOIN bock ON bock.z = c.e FULL JOIN beck ON beck.x = c.y WHERE ((f.a = $1 AND b.baz <> $2) OR (1 < 2 AND 2 < 3) OR (f.e in (1, $3, 3)) OR f.e BETWEEN 10 AND 20) GROUP BY f.a HAVING 0 < f.e ORDER BY b.baz DESC, c.quux LIMIT 50 OFFSET 10 "
+             ["SELECT DISTINCT f.*, b.baz, c.quux, b.bla AS bla_bla, now(), @x := 10 FROM foo f, baz b INNER JOIN draq ON f.b = draq.x LEFT JOIN clod c ON f.a = c.d RIGHT JOIN bock ON bock.z = c.e FULL JOIN beck ON beck.x = c.y WHERE ((f.a = $1 AND b.baz <> $2) OR (1 < 2 AND 2 < 3) OR (f.e in (1, $3, 3)) OR f.e BETWEEN 10 AND 20) GROUP BY f.a HAVING 0 < f.e ORDER BY b.baz DESC, c.quux, f.a NULLS FIRST LIMIT 50 OFFSET 10 "
               "bort" "gabba" 2])))))
 
 (deftest test-cast


### PR DESCRIPTION
SQL:2003 standard has introduced optional ability to specify the order in which NULL values are handled in ORDER BY clause. This pull request implements said functionality.

The only databases that support this functionality currently are PostgreSQL (since version 8.3) and Oracle (since at least 10g).
