### PR TITLE
Support locking selects

### DIFF
--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -188,6 +188,7 @@
    :order-by 190
    :limit 200
    :offset 210
+   :lock 215
    :values 220
    :query-values 230})
 
@@ -425,6 +426,22 @@
 
 (defmethod format-clause :offset [[_ offset] _]
   (str "OFFSET " (to-sql offset)))
+
+(defmulti format-lock-clause identity)
+
+(defmethod format-lock-clause :update [_]
+  "FOR UPDATE")
+
+(defmethod format-lock-clause :mysql-share [_]
+  "LOCK IN SHARE MODE")
+
+(defmethod format-lock-clause :postgresql-share [_]
+  "FOR SHARE")
+
+(defmethod format-clause :lock [[_ lock] _]
+  (let [{:keys [mode wait]} lock
+        clause (format-lock-clause mode)]
+    (str clause (when (false? wait) " NOWAIT"))))
 
 (defmethod format-clause :insert-into [[_ table] _]
   (if (and (sequential? table) (sequential? (first table)))

--- a/src/honeysql/helpers.clj
+++ b/src/honeysql/helpers.clj
@@ -154,6 +154,11 @@
     m
     (assoc m :offset (if (coll? o) (first o) o))))
 
+(defhelper lock [m lock]
+  (cond-> m
+          lock
+          (assoc :lock lock)))
+
 (defhelper modifiers [m ms]
   (if (nil? ms)
     m

--- a/test/honeysql/core_test.clj
+++ b/test/honeysql/core_test.clj
@@ -60,7 +60,12 @@
     (testing "SQL data formats correctly with alternate param naming"
       (is (= (sql/format m1 :params {:param1 "gabba" :param2 2} :parameterizer :postgresql)
              ["SELECT DISTINCT f.*, b.baz, c.quux, b.bla AS bla_bla, now(), @x := 10 FROM foo f, baz b INNER JOIN draq ON f.b = draq.x LEFT JOIN clod c ON f.a = c.d RIGHT JOIN bock ON bock.z = c.e FULL JOIN beck ON beck.x = c.y WHERE ((f.a = $1 AND b.baz <> $2) OR (1 < 2 AND 2 < 3) OR (f.e in (1, $3, 3)) OR f.e BETWEEN 10 AND 20) GROUP BY f.a HAVING 0 < f.e ORDER BY b.baz DESC, c.quux LIMIT 50 OFFSET 10 "
-              "bort" "gabba" 2])))))
+              "bort" "gabba" 2])))
+    (testing "Locking"
+      (is (= ["SELECT DISTINCT f.*, b.baz, c.quux, b.bla AS bla_bla, now(), @x := 10 FROM foo f, baz b INNER JOIN draq ON f.b = draq.x LEFT JOIN clod c ON f.a = c.d RIGHT JOIN bock ON bock.z = c.e FULL JOIN beck ON beck.x = c.y WHERE ((f.a = ? AND b.baz <> ?) OR (1 < 2 AND 2 < 3) OR (f.e in (1, ?, 3)) OR f.e BETWEEN 10 AND 20) GROUP BY f.a HAVING 0 < f.e ORDER BY b.baz DESC, c.quux LIMIT 50 OFFSET 10 FOR UPDATE "
+              "bort" "gabba" 2]
+             (sql/format (assoc m1 :lock {:mode :update})
+                         {:param1 "gabba" :param2 2}))))))
 
 (deftest test-cast
   (is (= ["SELECT foo, CAST(bar AS integer)"]


### PR DESCRIPTION
I use honeysql for a few projects and would like to use it to generate locking selects. My primary database is mysql, alas, but I've generalized the lock map value to support the primary modes for mysql and postgresql. Extension for novel lock clauses is possible via a multimethod.

If you're interested in merging this, I'll be happy to add documentation, specific tests for all the to-sql cases, and the helper.