### PR TITLE
Backfill the recent commits into the CHANGELOG

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,28 @@
-## 0.4.4 - UNRELEASED
+## 0.5.3 In development
 
-Improvements to the documentation, especially showing some recently added features, such as inserts
-and updates.
+* Add sql array type and reader literal (@loganmhb)
 
-[Closed Issues](https://github.com/jkk/honeysql/issues?q=milestone%3A0.4.4+is%3Aclosed)
+## 0.5.2
+
+* Add value type to inhibit interpreting clojure sequences as subqueries (@MichaelParam)
+* Improve documentation (@hlship)
+* Add type hints to avoid reflection (@MichaelBlume)
+* Allow database-specific query parameterization (@icambron, @MichaelBlume)
+
+## 0.5.1
+
+* Add :url to project.clj (@MichaelBlume)
+
+## 0.5.0
+
+* Support basic common table expressions (:with, :with-recursive) (@akhudek)
+* Make clause order extensible (@MichaelBlume)
+* Support extended INSERT INTO...SELECT syntax (@ddellacosta)
+* Update clojure version to 1.6.0 (@MichaelBlume)
+* Implement ToSql on Object, vastly improving performance (@MichaelBlume)
+* Support CAST(foo AS type) (@senior)
+* Support postgres-native parameters (@icambron)
+* Support :full-join (@justindell)
+* Expose :arglist metadata in defhelper (@hlship)
+* Improvements to the documentation, especially showing some recently added features, such as inserts
+  and updates.


### PR DESCRIPTION
This helps dependent projects review their integration to determine if
any need to be changed when they update honeysql.