### PR TITLE
Apply seq to sets when converting to sql

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## 0.5.3 In development
 
+* Convert seq param values to literal sql param lists (@dball)
 * Apply seq to sets when converting to sql (@dball)
 * Support locking selects (@dball)
 * Add sql array type and reader literal (@loganmhb)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## 0.5.3 In development
 
+* Apply seq to sets when converting to sql (@dball)
 * Support locking selects (@dball)
 * Add sql array type and reader literal (@loganmhb)
 

--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -248,10 +248,24 @@
         (into [sql-str] @*params*)
         [sql-str]))))
 
+(defprotocol Parameterizable
+  (to-params [value]))
+
+(extend-protocol Parameterizable
+  clojure.lang.Sequential
+  (to-params [value]
+    (paren-wrap (comma-join (mapv to-params value))))
+  clojure.lang.IPersistentSet
+  (to-params [value]
+    (to-params (seq value)))
+  java.lang.Object
+  (to-params [value]
+    (swap! *params* conj value)
+    (*parameterizer*)))
+
 (defn add-param [pname pval]
   (swap! *param-names* conj pname)
-  (swap! *params* conj pval)
-  (*parameterizer*))
+  (to-params pval))
 
 ;; Anonymous param name -- :_1, :_2, etc.
 (defn add-anon-param [pval]

--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -320,6 +320,9 @@
       (if *subquery?*
         (paren-wrap sql-str)
         sql-str)))
+  clojure.lang.IPersistentSet
+  (-to-sql [x]
+    (-to-sql (seq x)))
   nil
   (-to-sql [x] "NULL")
   SqlParam

--- a/test/honeysql/core_test.clj
+++ b/test/honeysql/core_test.clj
@@ -89,4 +89,30 @@
           (is (= ["SELECT * FROM customers WHERE (id in (1))"]
                  (sql/format {:select [:*]
                               :from [:customers]
-                              :where [:in :id values]}))))))))
+                              :where [:in :id values]})))
+          (is (= ["SELECT * FROM customers WHERE (id in (?))" 1]
+                 (sql/format {:select [:*]
+                              :from [:customers]
+                              :where [:in :id :?ids]}
+                             {:ids values}))))))
+    (testing "with more than one integer"
+      (let [values [1 2]]
+        (is (= ["SELECT * FROM customers WHERE (id in (1, 2))"]
+               (sql/format {:select [:*]
+                            :from [:customers]
+                            :where [:in :id values]})))
+        (is (= ["SELECT * FROM customers WHERE (id in (?, ?))" 1 2]
+               (sql/format {:select [:*]
+                            :from [:customers]
+                            :where [:in :id :?ids]}
+                           {:ids values})))))
+    (testing "with more than one string"
+      (let [values ["1" "2"]]
+        (is (= ["SELECT * FROM customers WHERE (id in (?, ?))" "1" "2"]
+               (sql/format {:select [:*]
+                            :from [:customers]
+                            :where [:in :id values]})
+               (sql/format {:select [:*]
+                            :from [:customers]
+                            :where [:in :id :?ids]}
+                           {:ids values})))))))

--- a/test/honeysql/core_test.clj
+++ b/test/honeysql/core_test.clj
@@ -80,3 +80,13 @@
            (columns :bar)
            (values [[(honeysql.format/value {:baz "my-val"})]])
            sql/format))))
+
+(deftest test-operators
+  (testing "in"
+    (doseq [[cname coll] [[:vector []] [:set #{}] [:list '()]]]
+      (testing (str "with values from a " (name cname))
+        (let [values (conj coll 1)]
+          (is (= ["SELECT * FROM customers WHERE (id in (1))"]
+                 (sql/format {:select [:*]
+                              :from [:customers]
+                              :where [:in :id values]}))))))))


### PR DESCRIPTION
This allows them to be used as values, e.g. for in clauses, as demonstrated in the test. The second commit goes further and provides a fix for #73, albeit with a question on the correct way to handle *param-names*.