### PR TITLE
[#75] Add support for exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ pom.xml*
 .lein-plugins
 .classpath
 .project
+.nrepl-port
 bin

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## 0.5.3 In development
 
+* Support exists syntax (@cddr)
 * Support locking selects (@dball)
 * Add sql array type and reader literal (@loganmhb)
 * Allow user to specify where in sort order NULLs fall (@mishok13)

--- a/test/honeysql/format_test.clj
+++ b/test/honeysql/format_test.clj
@@ -34,6 +34,16 @@
   (is (= (format-clause (first {:insert-into [[:foo [:a :b :c]] {:select [:d :e :f] :from [:baz]}]}) nil)
          "INSERT INTO foo (a, b, c) SELECT d, e, f FROM baz")))
 
+(deftest exists-test
+  (is (= (format {:exists {:select [:a] :from [:foo]}})
+         ["EXISTS (SELECT a FROM foo)"]))
+  (is (= (format {:select [:id]
+                  :from [:foo]
+                  :where [:exists {:select [1]
+                                   :from [:bar]
+                                   :where :deleted}]})
+         ["SELECT id FROM foo WHERE EXISTS (SELECT 1 FROM bar WHERE deleted)"])))
+
 (deftest array-test
   (is (= (format {:insert-into :foo
                   :columns [:baz]


### PR DESCRIPTION
Hi @jkk,

This PR implements #75.

The exists clause is useful for efficiently testing for existence without forcing the database to realize all the rows and then count them. If all we need to know is whether some relation exists, it's enough to find the first item in the relation and return true immediately.

IMO, it also makes some queries that would otherwise be joins more intuitive. For example to find "currently logged in users", you might use something like this....

```
select id
  from users
 where exists ( select 1 from sessions where user.id = session.user_id )
```
instead of
```
select id
  from users
inner join sessions on user.id = session.user_id
```
Please let me know if you'd like any changes or additional test coverage.

Thanks,
Andy