### PR TITLE
Fix the parameterizable protocol to include nil

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## 0.6.1 In development
 
+* Define parameterizable protocol on nil (@dball)
+
 ## 0.6.0
 
 * Convert seq param values to literal sql param lists (@dball)

--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -258,6 +258,11 @@
   clojure.lang.IPersistentSet
   (to-params [value pname]
     (to-params (seq value) pname))
+  nil
+  (to-params [value pname]
+    (swap! *params* conj value)
+    (swap! *param-names* conj pname)
+    (*parameterizer*))
   java.lang.Object
   (to-params [value pname]
     (swap! *params* conj value)

--- a/test/honeysql/core_test.clj
+++ b/test/honeysql/core_test.clj
@@ -82,6 +82,17 @@
            sql/format))))
 
 (deftest test-operators
+  (testing "="
+    (testing "with nil"
+      (is (= ["SELECT * FROM customers WHERE name IS NULL"]
+             (sql/format {:select [:*]
+                          :from [:customers]
+                          :where [:= :name nil]})))
+      (is (= ["SELECT * FROM customers WHERE name = ?" nil]
+             (sql/format {:select [:*]
+                          :from [:customers]
+                          :where [:= :name :?name]}
+                         {:name nil})))))
   (testing "in"
     (doseq [[cname coll] [[:vector []] [:set #{}] [:list '()]]]
       (testing (str "with values from a " (name cname))


### PR DESCRIPTION
I forgot that Object doesn't include nil on protocols.

I added test coverage demonstrating the regression, only to note that
parameterized and literal queries produce different sql for the nil
case. I believe only the former is actually valid ANSI SQL, though mysql
at least does not care.