### PR TITLE
Add '@@' as an infix operator for postgres text search

### DIFF
--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -73,7 +73,7 @@
 (def infix-fns
   #{"+" "-" "*" "/" "%" "mod" "|" "&" "^"
     "and" "or" "xor"
-    "in" "not in" "like" "not like" "regexp"})
+    "in" "not in" "like" "not like" "regexp" "@@"})
 
 (def fn-aliases
   {"is" "="


### PR DESCRIPTION
'@@' is an infix operator to test whether a query matches a search document.