### PR TITLE
quoting of AS clauses should not be splitted on "."

### DIFF
--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -303,7 +303,7 @@
              " AS "
              " ")
            (if (string? (second x))
-             (quote-identifier (second x))
+             (quote-identifier (second x) :split false)
              (to-sql (second x))))))
   SqlCall
   (to-sql [x]

--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -85,7 +85,9 @@
    "regex" "regexp"})
 
 (defprotocol ToSql
-  (to-sql [x]))
+  (to-sql
+    [x]
+    [x & args]))
 
 (defmulti fn-handler (fn [op & args] op))
 
@@ -277,13 +279,14 @@
 
 (extend-protocol ToSql
   clojure.lang.Keyword
-  (to-sql [x]
+  (to-sql [x & {:as args}]
     (let [s (name x)]
       (case (.charAt s 0)
         \% (let [call-args (string/split (subs s 1) #"\." 2)]
              (to-sql (apply call (map keyword call-args))))
         \? (to-sql (param (keyword (subs s 1))))
-        (quote-identifier x))))
+        (->> (apply concat (select-keys args [:split]))
+             (apply quote-identifier x)))))
   clojure.lang.Symbol
   (to-sql [x] (quote-identifier x))
   java.lang.Number
@@ -302,9 +305,13 @@
            (if (= :select *clause*)
              " AS "
              " ")
-           (if (string? (second x))
-             (quote-identifier (second x) :split false)
-             (to-sql (second x))))))
+           (cond (string? (second x))
+                 (quote-identifier (second x) :split false)
+                 (keyword? (second x))
+                 (to-sql (second x) :split false)
+                 :else
+                 (to-sql (second x))
+                 ))))
   SqlCall
   (to-sql [x]
     (binding [*fn-context?* true]

--- a/test/honeysql/core_test.clj
+++ b/test/honeysql/core_test.clj
@@ -127,3 +127,10 @@
                             :from [:customers]
                             :where [:in :id :?ids]}
                            {:ids values})))))))
+
+(deftest test-quoting
+  (testing ":quoting :ansi"
+    (is (= ["SELECT \"b\".\"bla\" AS \"bla.bla\", \"b\".\"bla\" AS \"blu.blu\" FROM \"baz\" \"b\"" ]
+           (-> (select [:b.bla :bla.bla] [:b.bla "blu.blu"])
+               (from [:baz :b])
+               (sql/format :quoting :ansi))))))


### PR DESCRIPTION
quoting of AS clauses should not be splitted on "."

Running

``` clojure
(-> (select [:ad.id "myad.id"]) (from :ad) (sql/format :quoting :mysql) )
```

produces

``` sql
["SELECT `ad`.`id` AS `myad`.`id` FROM `ad`"]
```

Which causes a MySQLSyntaxErrorException. The correct quoting would be

``` sql
["SELECT `ad`.`id` AS `myad.id` FROM `ad`"]
```

Enclosing the whole alias like this, works for both ansi and oracle style quoting(ansi accepts both splitting and not splitting)
