### PR TITLE
Allow mysql upserts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## 0.6.2 In development
 
+* Support mysql upserts (@dball)
+
 ## 0.6.1
 
 * Define parameterizable protocol on nil (@dball)

--- a/README.md
+++ b/README.md
@@ -143,6 +143,22 @@ The column values do not have to be literals, they can be nested queries:
     "user"]
 ```
 
+MySQL upserts are supported:
+
+```clj
+(-> (insert-into :properties)
+    (columns :name :surname :age)
+    (values
+     [["Jon" "Smith" 34]
+      ["Andrew" "Cooper" 12]
+      ["Jane" "Daniels" 56]])
+    (upsert :mysql {:age #sql/call [:values :age]})
+    sql/format)
+=> ["INSERT INTO properties (name, surname, age)
+     VALUES (?, ?, 34), (?, ?, 12), (?, ?, 56)"
+     "Jon" "Smith" "Andrew" "Cooper" "Jane" "Daniels"]
+```
+
 Updates are possible too (note the double S in `sset` to avoid clashing
 with `clojure.core/set`):
 

--- a/src/honeysql/helpers.clj
+++ b/src/honeysql/helpers.clj
@@ -159,6 +159,9 @@
           lock
           (assoc :lock lock)))
 
+(defhelper upsert [m mode updates]
+  (assoc m :upsert {:mode mode :updates updates}))
+
 (defhelper modifiers [m ms]
   (if (nil? ms)
     m

--- a/test/honeysql/format_test.clj
+++ b/test/honeysql/format_test.clj
@@ -32,7 +32,23 @@
   (is (= (format-clause (first {:insert-into [:foo {:select [:bar] :from [:baz]}]}) nil)
          "INSERT INTO foo SELECT bar FROM baz"))
   (is (= (format-clause (first {:insert-into [[:foo [:a :b :c]] {:select [:d :e :f] :from [:baz]}]}) nil)
-         "INSERT INTO foo (a, b, c) SELECT d, e, f FROM baz")))
+         "INSERT INTO foo (a, b, c) SELECT d, e, f FROM baz"))
+  (is (= (format {:insert-into :letters
+                  :columns [:domain_key]
+                  :values [["a"] ["b"] ["c"]]})
+         ["INSERT INTO letters (domain_key) VALUES (?), (?), (?)" "a" "b" "c"]))
+  (is (= (format {:insert-into :letters
+                  :columns [:domain_key]
+                  :values [["a"] ["b"] ["c"]]
+                  :upsert {:mode :mysql
+                           :updates {:id :id}}})
+         ["INSERT INTO letters (domain_key) VALUES (?), (?), (?) ON DUPLICATE KEY UPDATE id=id" "a" "b" "c"]))
+  (is (= (format {:insert-into :letters
+                  :columns [:domain_key :rank]
+                  :values [["a" 1] ["b" 2] ["c" 3]]
+                  :upsert {:mode :mysql
+                           :updates {:rank #sql/call [:values :rank]}}})
+         ["INSERT INTO letters (domain_key, rank) VALUES (?, 1), (?, 2), (?, 3) ON DUPLICATE KEY UPDATE rank=values(rank)" "a" "b" "c"])))
 
 (deftest exists-test
   (is (= (format {:exists {:select [:a] :from [:foo]}})


### PR DESCRIPTION
While I have a bespoke version of this externally, it would be nice to
gracefully take advantage of honeysql's reader literals for sql fn calls
and the like.
