### PR TITLE
Fix the union clause

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## 0.6.2 In development
 
+* Fix union clause (@dball)
+
 ## 0.6.1
 
 * Define parameterizable protocol on nil (@dball)

--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -519,7 +519,7 @@
   (str "WITH RECURSIVE " (comma-join (map cte->sql ctes))))
 
 (defmethod format-clause :union [[_ maps] _]
-  (string/join " UNION " (map to-sql maps)))
+  (str "UNION " (string/join " UNION " (map to-sql maps))))
 
 (defmethod format-clause :union-all [[_ maps] _]
-  (string/join " UNION ALL " (map to-sql maps)))
+  (str "UNION ALL " (string/join " UNION ALL " (map to-sql maps))))


### PR DESCRIPTION
The previous version omits the UNION between the base query and the
first of the union queries