### PR TITLE
Document the correct use of the :union clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ Queries can be nested:
 => ["SELECT * FROM foo WHERE (foo.a IN (SELECT a FROM bar))"]
 ```
 
+Queries may be united within a :union or :union-all keyword:
+
+```clj
+(sql/format {:union [(-> (select :*) (from :foo))
+                     (-> (select :*) (from :bar))]})
+=> ["(SELECT * FROM foo) UNION (SELECT * FROM bar)"]
+```
+
 Keywords that begin with `%` are interpreted as SQL function calls:
 
 ```clj


### PR DESCRIPTION
My co-workers and I naively expected to include the :union in the
primary query, not as a container. This is a good representation, but
merits explanation.