### PR TITLE
Added support for preserving dashes in quoted names.

### DIFF
--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -38,6 +38,8 @@
 
 (def ^:dynamic *subquery?* false)
 
+(def ^:dynamic *allow-dashed-names?* true)
+
 (def ^:private quote-fns
   {:ansi #(str \" % \")
    :mysql #(str \` % \`)
@@ -55,12 +57,13 @@
   (string/replace s "-" "_"))
 
 (defn quote-identifier [x & {:keys [style split] :or {split true}}]
-  (let [qf (if style
+  (let [name-transform-fn (if *allow-dashed-names?* identity undasherize)
+        qf (if style
              (quote-fns style)
              *quote-identifier-fn*)
         s (cond
-            (or (keyword? x) (symbol? x)) (undasherize (name x))
-            (string? x) (if qf x (undasherize x))
+            (or (keyword? x) (symbol? x)) (name-transform-fn (name x))
+            (string? x) (if qf x (name-transform-fn x))
             :else (str x))]
     (if-not qf
       s
@@ -228,7 +231,8 @@
               *param-names* (atom [])
               *input-params* (atom params)
               *quote-identifier-fn* (quote-fns (:quoting opts))
-              *parameterizer* (parameterizers (or (:parameterizer opts) :jdbc))]
+              *parameterizer* (parameterizers (or (:parameterizer opts) :jdbc))
+              *allow-dashed-names?* (:allow-dashed-names opts)]
       (let [sql-str (to-sql sql-map)]
         (if (seq @*params*)
           (if (:return-param-names opts)

--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -38,7 +38,7 @@
 
 (def ^:dynamic *subquery?* false)
 
-(def ^:dynamic *allow-dashed-names?* true)
+(def ^:dynamic *allow-dashed-names?* false)
 
 (def ^:private quote-fns
   {:ansi #(str \" % \")


### PR DESCRIPTION
This pull request is to resolve the following issue by adding optional functionality.
https://github.com/jkk/honeysql/issues/80

This is what normally happens:
```clojure
(format {:select [:*] :from [[:some-new-schema.user-accounts :ua]] :where [:= :ua.user-id 12345]} :quoting :ansi)
;;; Yields the following:
["SELECT * FROM \"some_new_schema\".\"user_accounts\" \"ua\" WHERE \"ua\".\"user_id\" = 12345"]
```

This change supports doing the following while allowing nothing to change if the ```:allow-dashed-names``` option is not provided.

```clojure
(format {:select [:*] :from [[:some-new-schema.user-accounts :ua]] :where [:= :ua.user-id 12345]} :quoting :ansi :allow-dashed-names true)
;;; Results in:
["SELECT * FROM \"some-new-schema\".\"user-accounts\" \"ua\" WHERE \"ua\".\"user-id\" = 12345"]
```

I think that this change will make a lot of PostgreSQL developers happy. I know it will for me. :)