### PR TITLE
Support column names in :with clauses

### DIFF
--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -507,10 +507,12 @@
 
 (defmethod format-clause :delete-from [[_ table] _]
   (str "DELETE FROM " (to-sql table)))
-  
+
 (defn cte->sql
   [[cte-name query]]
-  (str (to-sql cte-name) " AS " (to-sql query)))
+  (if (sequential? cte-name)
+    (str (to-sql (first cte-name)) " " (to-sql (second cte-name)) " AS " (to-sql query))
+    (str (to-sql cte-name) " AS " (to-sql query))))
 
 (defmethod format-clause :with [[_ ctes] _]
   (str "WITH " (comma-join (map cte->sql ctes))))

--- a/test/honeysql/format_test.clj
+++ b/test/honeysql/format_test.clj
@@ -24,7 +24,10 @@
          "WITH query AS SELECT foo FROM bar"))
   (is (= (format-clause
           (first {:with-recursive [[:query {:select [:foo] :from [:bar]}]]}) nil)
-         "WITH RECURSIVE query AS SELECT foo FROM bar")))
+         "WITH RECURSIVE query AS SELECT foo FROM bar"))
+  (is (= (format-clause
+           (first {:with [[[:static {:columns [:a :b :c]}] {:values [[1 2 3] [4 5 6]]}]]}) nil)
+         "WITH static (a, b, c) AS VALUES (1, 2, 3), (4, 5, 6)")))
 
 (deftest insert-into
   (is (= (format-clause (first {:insert-into :foo}) nil)


### PR DESCRIPTION
```clj
{:with [[[:static {:columns [:a :b :c]}]
         {:values [[1 2 3] [4 5 6]]}]]}
```

```sql
WITH static (a, b, c) AS (VALUES (1, 2, 3), (4, 5, 6))
```

This would fix #84 