### PR TITLE
add intersect support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## 0.6.3 In development
 
+* Add support for :intersect clause (@jakemcc)
+
 ## 0.6.2
 
 Support column names in :with clauses (@emidln)

--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -531,6 +531,9 @@
 (defmethod format-clause :union-all [[_ maps] _]
   (string/join " UNION ALL " (map to-sql maps)))
 
+(defmethod format-clause :intersect [[_ maps] _]
+  (string/join " INTERSECT " (map to-sql maps)))
+
 (defmethod fn-handler "case" [_ & clauses]
   (str "CASE "
        (space-join

--- a/src/honeysql/helpers.clj
+++ b/src/honeysql/helpers.clj
@@ -236,3 +236,6 @@
 
 (defmethod build-clause :union-all [_ m maps]
   (assoc m :union-all maps))
+
+(defmethod build-clause :intersect [_ m maps]
+  (assoc m :intersect maps))

--- a/test/honeysql/format_test.clj
+++ b/test/honeysql/format_test.clj
@@ -79,3 +79,8 @@
   (is (= (format {:union-all [{:select [:foo] :from [:bar1]}
                               {:select [:foo] :from [:bar2]}]})
          ["(SELECT foo FROM bar1) UNION ALL (SELECT foo FROM bar2)"])))
+
+(deftest intersect-test
+  (is (= (format {:intersect [{:select [:foo] :from [:bar1]}
+                              {:select [:foo] :from [:bar2]}]})
+         ["(SELECT foo FROM bar1) INTERSECT (SELECT foo FROM bar2)"])))


### PR DESCRIPTION
PR adds support of adding `:intersect` clauses to queries. I had already extended honeysql to add support for :intersect and saw that others were looking for it.

Should solve #102.