### PR TITLE
escape quote characters in quoted identifiers

### DIFF
--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -41,10 +41,10 @@
 (def ^:dynamic *allow-dashed-names?* false)
 
 (def ^:private quote-fns
-  {:ansi #(str \" % \")
-   :mysql #(str \` % \`)
-   :sqlserver #(str \[ % \])
-   :oracle #(str \" % \")})
+  {:ansi #(str \" (string/replace % "\"" "\"\"") \")
+   :mysql #(str \` (string/replace % "`" "``") \`)
+   :sqlserver #(str \[ (string/replace % "]" "]]") \])
+   :oracle #(str \" (string/replace % "\"" "\"\"") \")})
 
 (def ^:private parameterizers
   {:postgresql #(str "$" (swap! *all-param-counter* inc))

--- a/test/honeysql/format_test.clj
+++ b/test/honeysql/format_test.clj
@@ -16,7 +16,11 @@
     3 "3"
     'foo "foo"
     :foo-bar "foo_bar")
-  (is (= (quote-identifier "*" :style :ansi) "*")))
+  (is (= (quote-identifier "*" :style :ansi) "*"))
+  (is (= (quote-identifier "foo\"bar" :style :ansi) "\"foo\"\"bar\""))
+  (is (= (quote-identifier "foo\"bar" :style :oracle) "\"foo\"\"bar\""))
+  (is (= (quote-identifier "foo`bar" :style :mysql) "`foo``bar`"))
+  (is (= (quote-identifier "foo]bar" :style :sqlserver) "[foo]]bar]")))
 
 (deftest test-dashed-quote
   (binding [*allow-dashed-names?* true]


### PR DESCRIPTION
Pull request for issue #109

`quote-identifier` now escapes the quote character.