### PR TITLE
allow joins without a pred

### DIFF
--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -414,10 +414,10 @@
   (str "WHERE " (format-predicate* pred)))
 
 (defn format-join [type table pred]
-  (str (when type
-         (str (string/upper-case (name type)) " "))
-       "JOIN " (to-sql table)
-       " ON " (format-predicate* pred)))
+  (cond-> (str (when type
+                 (str (string/upper-case (name type)) " "))
+               "JOIN " (to-sql table))
+    pred (str " ON " (format-predicate* pred))))
 
 (defmethod format-clause :join [[_ join-groups] _]
   (space-join (map #(apply format-join :inner %)

--- a/test/honeysql/core_test.clj
+++ b/test/honeysql/core_test.clj
@@ -165,3 +165,11 @@
          (-> (select (sql/call :min "time"))
              (from "table")
              sql/format))))
+
+(deftest join-test
+  (testing "nil join"
+    (is (= ["SELECT * FROM foo INNER JOIN x ON foo.id = x.id INNER JOIN y"]
+           (-> (select :*)
+               (from :foo)
+               (join :x [:= :foo.id :x.id] :y nil)
+               sql/format)))))


### PR DESCRIPTION
simple change to `format-join` supporting `nil` predicates