### PR TITLE
F/quoted functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,16 @@ To be able to use dashes in quoted names, you can pass ```:allow-dashed-names tr
 => ["SELECT \"f\".\"foo-id\", \"f\".\"foo-name\" FROM \"foo-bar\" \"f\" WHERE \"f\".\"foo-id\" = 12345"]
 ```
 
+In some cases, you may want to quote function calls. To do this, you can use the
+```sql/call-quoted``` function instead of the ```sql/call``` function.
+
+```clj
+(sql/format
+  {:select (sql/quoted-call :my-schema.some-function 1 2 3)}
+  :quoting :ansi :allow-quoted-names? true)
+=> ["SELECT \"my-schema\".\"some-function\"(1, 2, 3)"]
+```
+
 Here's a big, complicated query. Note that Honey SQL makes no attempt to verify that your queries make any sense. It merely renders surface syntax.
 
 ```clj

--- a/src/honeysql/core.clj
+++ b/src/honeysql/core.clj
@@ -7,6 +7,7 @@
             [clojure.string :as string]))
 
 (defalias call types/call)
+(defalias call-quoted types/call-quoted)
 (defalias raw types/raw)
 (defalias param types/param)
 (defalias format format/format)

--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -312,9 +312,9 @@
   SqlCall
   (to-sql [x]
     (binding [*fn-context?* true]
-       (let [fn-name (name (.-name x))
-             fn-name (fn-aliases fn-name fn-name)]
-         (apply fn-handler fn-name (.-args x)))))
+       (let [quoted? (.-quoted? x)
+             fn-name ((if quoted? to-sql name) (.-name x))]
+         (apply fn-handler (fn-aliases fn-name fn-name) (.-args x)))))
   SqlRaw
   (to-sql [x] (.-s x))
   clojure.lang.IPersistentMap

--- a/src/honeysql/types.clj
+++ b/src/honeysql/types.clj
@@ -1,18 +1,24 @@
 (ns honeysql.types)
 
-(defrecord SqlCall [name args])
+(defrecord SqlCall [name args quoted?])
 
 (defn call
   "Represents a SQL function call. Name should be a keyword."
   [name & args]
-  (SqlCall. name args))
+  (SqlCall. name args false))
+
+(defn call-quoted
+  "Represents a SQL function call that must be quoted. Like the normal SqlCall
+  the name should be a keyword."
+  [name & args] (SqlCall. name args true))
 
 (defn read-sql-call [form]
   ;; late bind so that we get new class on REPL reset
   (apply (resolve `call) form))
 
 (defmethod print-method SqlCall [^SqlCall o ^java.io.Writer w]
-  (.write w (str "#sql/call " (pr-str (into [(.-name o)] (.-args o))))))
+  (.write w (str "#sql/call" (when (.-quoted? o) "-quoted")
+                 " " (pr-str (into [(.-name o)] (.-args o))))))
 
 (defmethod print-dup SqlCall [o w]
   (print-method o w))

--- a/test/honeysql/core_test.clj
+++ b/test/honeysql/core_test.clj
@@ -166,6 +166,12 @@
              (from "table")
              sql/format))))
 
+(deftest test-quoted-call
+  (is (= ["SELECT \"foo\".\"bar\"(1, 2, 3)"]
+         (sql/format
+           {:select [(sql/call-quoted :foo.bar 1 2 3)]}
+           :quoting :ansi))))
+
 (deftest join-test
   (testing "nil join"
     (is (= ["SELECT * FROM foo INNER JOIN x ON foo.id = x.id INNER JOIN y"]


### PR DESCRIPTION
See #115.

This adds support for being able to quote database function calls. This was required for PostgreSQL because user defined functions can be fully qualified and must be quoted if the name contains certain characters. As a result, I updated HoneySQL to support the following which I will quote from the addition I made to the README:

In some cases, you may want to quote function calls. To do this, you can use the ```sql/call-quoted``` function instead of the ```sql/call``` function.

```clj
(sql/format
  {:select (sql/quoted-call :my-schema.some-function 1 2 3)}
  :quoting :ansi :allow-quoted-names? true)
=> ["SELECT \"my-schema\".\"some-function\"(1, 2, 3)"]
```