### PR TITLE
Allow namespaced keywords and symbols

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## 0.7.1 In development
 
+* Allow namespaced keywords and symbols for queries. (@jrdoane)
+
 ## 0.7.0
 
 * Parameterize numbers, properly handle NaN, Infinity, -Infinity (@akhudek)

--- a/src/honeysql/format.clj
+++ b/src/honeysql/format.clj
@@ -62,7 +62,10 @@
              (quote-fns style)
              *quote-identifier-fn*)
         s (cond
-            (or (keyword? x) (symbol? x)) (name-transform-fn (name x))
+            (or (keyword? x) (symbol? x))
+            (name-transform-fn
+              (str (when-let [n (namespace x)]
+                     (str n "/")) (name x)))
             (string? x) (if qf x (name-transform-fn x))
             :else (str x))]
     (if-not qf

--- a/test/honeysql/format_test.clj
+++ b/test/honeysql/format_test.clj
@@ -29,6 +29,10 @@
     (is (= (quote-identifier :foo-bar.moo-bar :style :ansi)
            "\"foo-bar\".\"moo-bar\""))))
 
+(deftest test-namespaced-identifier
+  (is (= (quote-identifier :foo/bar) "foo/bar"))
+  (is (= (quote-identifier :foo/bar :style :ansi) "\"foo/bar\"")))
+
 (deftest test-cte
   (is (= (format-clause
           (first {:with [[:query {:select [:foo] :from [:bar]}]]}) nil)


### PR DESCRIPTION
This pull request solves this problem: https://github.com/jkk/honeysql/issues/131

This should preserve the namespace portion of a keyword if it is used in a query. This will allow developers to use field names that contain forward slashes by using namespaced keywords and symbols in Clojure.
