### PR TITLE
Address #138 : add priority for union/union-all

### DIFF
--- a/src/honeysql/format.cljc
+++ b/src/honeysql/format.cljc
@@ -174,7 +174,9 @@
 
 (def default-clause-priorities
   "Determines the order that clauses will be placed within generated SQL"
-  {:with 30
+  {:union 20
+   :union-all 25
+   :with 30
    :with-recursive 40
    :select 50
    :insert-into 60


### PR DESCRIPTION
By prioritizing union / union-all to happen early on, complex queries
with order by / limit / offset etc will be correctly formatted _after_
the union / union-all clause has been formatted.