### PR TITLE
Don't parenthesize the subclauses of a UNION, UNION ALL, or INTERSECT clause.

### DIFF
--- a/src/honeysql/format.cljc
+++ b/src/honeysql/format.cljc
@@ -560,13 +560,16 @@
   (str "WITH RECURSIVE " (comma-join (map cte->sql ctes))))
 
 (defmethod format-clause :union [[_ maps] _]
-  (string/join " UNION " (map to-sql maps)))
+  (binding [*subquery?* false]
+    (string/join " UNION " (map to-sql maps))))
 
 (defmethod format-clause :union-all [[_ maps] _]
-  (string/join " UNION ALL " (map to-sql maps)))
+  (binding [*subquery?* false]
+    (string/join " UNION ALL " (map to-sql maps))))
 
 (defmethod format-clause :intersect [[_ maps] _]
-  (string/join " INTERSECT " (map to-sql maps)))
+  (binding [*subquery?* false]
+    (string/join " INTERSECT " (map to-sql maps))))
 
 (defmethod fn-handler "case" [_ & clauses]
   (str "CASE "

--- a/test/honeysql/format_test.cljc
+++ b/test/honeysql/format_test.cljc
@@ -96,3 +96,17 @@
   (is (= (format {:intersect [{:select [:foo] :from [:bar1]}
                               {:select [:foo] :from [:bar2]}]})
          ["SELECT foo FROM bar1 INTERSECT SELECT foo FROM bar2"])))
+
+(deftest inner-parts-test
+  (testing "The correct way to apply ORDER BY to various parts of a UNION"
+    (is (= (format
+             {:union
+              [{:select [:amount :id :created_on]
+                :from [:transactions]}
+               {:select [:amount :id :created_on]
+                :from [{:select [:amount :id :created_on]
+                        :from [:other_transactions]
+                        :order-by [[:amount :desc]]
+                        :limit 5}]}]
+              :order-by [[:amount :asc]]})
+           ["SELECT amount, id, created_on FROM transactions UNION SELECT amount, id, created_on FROM (SELECT amount, id, created_on FROM other_transactions ORDER BY amount DESC LIMIT ?) ORDER BY amount ASC" 5]))))

--- a/test/honeysql/format_test.cljc
+++ b/test/honeysql/format_test.cljc
@@ -77,16 +77,22 @@
          ["INSERT INTO foo (baz) VALUES (ARRAY[?, ?, ?])" "one" "two" "three"])))
 
 (deftest union-test
+  ;; UNION and INTERSECT subexpressions should not be parenthesized.
+  ;; If you need to add more complex expressions, use a subquery like this:
+  ;;   SELECT foo FROM bar1
+  ;;   UNION
+  ;;   SELECT foo FROM (SELECT foo FROM bar2 ORDER BY baz LIMIT 2)
+  ;;   ORDER BY foo ASC
   (is (= (format {:union [{:select [:foo] :from [:bar1]}
                           {:select [:foo] :from [:bar2]}]})
-         ["(SELECT foo FROM bar1) UNION (SELECT foo FROM bar2)"])))
+         ["SELECT foo FROM bar1 UNION SELECT foo FROM bar2"])))
 
 (deftest union-all-test
   (is (= (format {:union-all [{:select [:foo] :from [:bar1]}
                               {:select [:foo] :from [:bar2]}]})
-         ["(SELECT foo FROM bar1) UNION ALL (SELECT foo FROM bar2)"])))
+         ["SELECT foo FROM bar1 UNION ALL SELECT foo FROM bar2"])))
 
 (deftest intersect-test
   (is (= (format {:intersect [{:select [:foo] :from [:bar1]}
                               {:select [:foo] :from [:bar2]}]})
-         ["(SELECT foo FROM bar1) INTERSECT (SELECT foo FROM bar2)"])))
+         ["SELECT foo FROM bar1 INTERSECT SELECT foo FROM bar2"])))


### PR DESCRIPTION
Fixes #141.

As far as I've seen, the parens aren't allowed by the standard. Any use of the parens in engines that permit them can be solved by adding a simple subquery — see note in the test — so the best option is to simply remove them altogether.
