### PR TITLE
Fix operator/function calls in value positions

### DIFF
--- a/src/honeysql/format.cljc
+++ b/src/honeysql/format.cljc
@@ -37,6 +37,8 @@
 
 (def ^:dynamic *fn-context?* false)
 
+(def ^:dynamic *value-context?* false)
+
 (def ^:dynamic *subquery?* false)
 
 (def ^:dynamic *allow-dashed-names?* false)
@@ -91,6 +93,10 @@
 (defprotocol ToSql
   (to-sql [x]))
 
+(defn to-sql-value [x]
+  (binding [*value-context?* true]
+    (to-sql x)))
+
 (defmulti fn-handler (fn [op & args] op))
 
 (defn expand-binary-ops [op & args]
@@ -121,40 +127,40 @@
   (if (seq more)
     (apply expand-binary-ops "=" a b more)
     (cond
-     (nil? a) (str (to-sql b) " IS NULL")
-     (nil? b) (str (to-sql a) " IS NULL")
-     :else (str (to-sql a) " = " (to-sql b)))))
+     (nil? a) (str (to-sql-value b) " IS NULL")
+     (nil? b) (str (to-sql-value a) " IS NULL")
+     :else (str (to-sql-value a) " = " (to-sql-value b)))))
 
 (defmethod fn-handler "<>" [_ a b & more]
   (if (seq more)
     (apply expand-binary-ops "<>" a b more)
     (cond
-     (nil? a) (str (to-sql b) " IS NOT NULL")
-     (nil? b) (str (to-sql a) " IS NOT NULL")
-     :else (str (to-sql a) " <> " (to-sql b)))))
+     (nil? a) (str (to-sql-value b) " IS NOT NULL")
+     (nil? b) (str (to-sql-value a) " IS NOT NULL")
+     :else (str (to-sql-value a) " <> " (to-sql-value b)))))
 
 (defmethod fn-handler "<" [_ a b & more]
   (if (seq more)
     (apply expand-binary-ops "<" a b more)
-    (str (to-sql a) " < " (to-sql b))))
+    (str (to-sql-value a) " < " (to-sql-value b))))
 
 (defmethod fn-handler "<=" [_ a b & more]
   (if (seq more)
     (apply expand-binary-ops "<=" a b more)
-    (str (to-sql a) " <= " (to-sql b))))
+    (str (to-sql-value a) " <= " (to-sql-value b))))
 
 (defmethod fn-handler ">" [_ a b & more]
   (if (seq more)
     (apply expand-binary-ops ">" a b more)
-    (str (to-sql a) " > " (to-sql b))))
+    (str (to-sql-value a) " > " (to-sql-value b))))
 
 (defmethod fn-handler ">=" [_ a b & more]
   (if (seq more)
     (apply expand-binary-ops ">=" a b more)
-    (str (to-sql a) " >= " (to-sql b))))
+    (str (to-sql-value a) " >= " (to-sql-value b))))
 
 (defmethod fn-handler "between" [_ field lower upper]
-  (str (to-sql field) " BETWEEN " (to-sql lower) " AND " (to-sql upper)))
+  (str (to-sql-value field) " BETWEEN " (to-sql-value lower) " AND " (to-sql-value upper)))
 
 ;; Handles MySql's MATCH (field) AGAINST (pattern). The third argument
 ;; can be a set containing one or more of :boolean, :natural, or :expand.
@@ -163,7 +169,7 @@
        (comma-join
         (map to-sql (if (coll? fields) fields [fields])))
        ") AGAINST ("
-       (to-sql pattern)
+       (to-sql-value pattern)
        (when (seq opts)
          (str " " (space-join (for [opt opts]
                                 (case opt
@@ -310,10 +316,17 @@
       (paren-wrap sql-str)
       sql-str)))
 
+(declare format-predicate*)
+
 (defn seq->sql [x]
-  (if *fn-context?*
+  (cond
+    *value-context?*
+    ;; sequences are operators/functions
+    (format-predicate* x)
+    *fn-context?*
     ;; list argument in fn call
     (paren-wrap (comma-join (map to-sql x)))
+    :else
     ;; alias
     (str (to-sql (first x))
          ; Omit AS in FROM, JOIN, etc. - Oracle doesn't allow it

--- a/test/honeysql/format_test.cljc
+++ b/test/honeysql/format_test.cljc
@@ -110,3 +110,10 @@
                         :limit 5}]}]
               :order-by [[:amount :asc]]})
            ["SELECT amount, id, created_on FROM transactions UNION SELECT amount, id, created_on FROM (SELECT amount, id, created_on FROM other_transactions ORDER BY amount DESC LIMIT ?) ORDER BY amount ASC" 5]))))
+
+(deftest compare-expressions-test
+  (testing "Sequences should be fns when in value/comparison spots"
+    (is (= ["SELECT foo FROM bar WHERE (col1 mod ?) = (col2 + ?)" 4 4]
+           (format {:select [:foo]
+                    :from [:bar]
+                    :where [:= [:mod :col1 4] [:+ :col2 4]]})))))


### PR DESCRIPTION
Current version of the honeysql vector syntax does not correctly handle mathematical operators in value (comparison) positions. See the attached test and fix.

