### PR TITLE
Add helpers for :with and :with-recursive clauses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## 0.8.3 In development
 
+* Add helpers for :with and :with-recursive clauses
+
 ## 0.8.2
 
 * Don't parenthesize the subclauses of a UNION, UNION ALL, or INTERSECT clause. (@rnewman)

--- a/src/honeysql/helpers.cljc
+++ b/src/honeysql/helpers.cljc
@@ -238,10 +238,10 @@
   ([table] (delete-from nil table))
   ([m table] (build-clause :delete-from m table)))
 
-(defmethod build-clause :with [_ m ctes]
+(defhelper with [m ctes]
   (assoc m :with ctes))
 
-(defmethod build-clause :with-recursive [_ m ctes]
+(defhelper with-recursive [m ctes]
   (assoc m :with-recursive ctes))
 
 (defmethod build-clause :union [_ m maps]

--- a/test/honeysql/core_test.cljc
+++ b/test/honeysql/core_test.cljc
@@ -6,13 +6,16 @@
             [honeysql.helpers :refer [select modifiers from join left-join
                                       right-join full-join where group having
                                       order-by limit offset values columns
-                                      insert-into]]
+                                      insert-into with]]
             honeysql.format-test))
 
 ;; TODO: more tests
 
 (deftest test-select
-  (let [m1 (-> (select :f.* :b.baz :c.quux [:b.bla :bla-bla]
+  (let [m1 (-> (with [:cte (-> (select :*)
+                               (from :example)
+                               (where [:= :example-column 0]))])
+               (select :f.* :b.baz :c.quux [:b.bla :bla-bla]
                        :%now (sql/raw "@x := 10"))
                ;;(un-select :c.quux)
                (modifiers :distinct)
@@ -32,7 +35,10 @@
                (order-by [:b.baz :desc] :c.quux [:f.a :nulls-first])
                (limit 50)
                (offset 10))
-        m2 {:select [:f.* :b.baz :c.quux [:b.bla :bla-bla]
+        m2 {:with [[:cte {:select [:*]
+                          :from [:example]
+                          :where [:= :example-column 0]}]]
+            :select [:f.* :b.baz :c.quux [:b.bla :bla-bla]
                      :%now (sql/raw "@x := 10")]
             ;;:un-select :c.quux
             :modifiers :distinct
@@ -57,18 +63,18 @@
     (testing "Various construction methods are consistent"
       (is (= m1 m3 m4)))
     (testing "SQL data formats correctly"
-      (is (= ["SELECT DISTINCT f.*, b.baz, c.quux, b.bla AS bla_bla, now(), @x := 10 FROM foo f, baz b INNER JOIN draq ON f.b = draq.x LEFT JOIN clod c ON f.a = c.d RIGHT JOIN bock ON bock.z = c.e FULL JOIN beck ON beck.x = c.y WHERE ((f.a = ? AND b.baz <> ?) OR (? < ? AND ? < ?) OR (f.e in (?, ?, ?)) OR f.e BETWEEN ? AND ?) GROUP BY f.a HAVING ? < f.e ORDER BY b.baz DESC, c.quux, f.a NULLS FIRST LIMIT ? OFFSET ? "
-              "bort" "gabba" 1 2 2 3 1 2 3 10 20 0 50 10]
+      (is (= ["WITH cte AS (SELECT * FROM example WHERE example_column = ?) SELECT DISTINCT f.*, b.baz, c.quux, b.bla AS bla_bla, now(), @x := 10 FROM foo f, baz b INNER JOIN draq ON f.b = draq.x LEFT JOIN clod c ON f.a = c.d RIGHT JOIN bock ON bock.z = c.e FULL JOIN beck ON beck.x = c.y WHERE ((f.a = ? AND b.baz <> ?) OR (? < ? AND ? < ?) OR (f.e in (?, ?, ?)) OR f.e BETWEEN ? AND ?) GROUP BY f.a HAVING ? < f.e ORDER BY b.baz DESC, c.quux, f.a NULLS FIRST LIMIT ? OFFSET ? "
+              0 "bort" "gabba" 1 2 2 3 1 2 3 10 20 0 50 10]
              (sql/format m1 {:param1 "gabba" :param2 2}))))
     #?(:clj (testing "SQL data prints and reads correctly"
               (is (= m1 (read-string (pr-str m1))))))
     (testing "SQL data formats correctly with alternate param naming"
       (is (= (sql/format m1 :params {:param1 "gabba" :param2 2} :parameterizer :postgresql)
-             ["SELECT DISTINCT f.*, b.baz, c.quux, b.bla AS bla_bla, now(), @x := 10 FROM foo f, baz b INNER JOIN draq ON f.b = draq.x LEFT JOIN clod c ON f.a = c.d RIGHT JOIN bock ON bock.z = c.e FULL JOIN beck ON beck.x = c.y WHERE ((f.a = $1 AND b.baz <> $2) OR ($3 < $4 AND $5 < $6) OR (f.e in ($7, $8, $9)) OR f.e BETWEEN $10 AND $11) GROUP BY f.a HAVING $12 < f.e ORDER BY b.baz DESC, c.quux, f.a NULLS FIRST LIMIT $13 OFFSET $14 "
-              "bort" "gabba" 1 2 2 3 1 2 3 10 20 0 50 10])))
+             ["WITH cte AS (SELECT * FROM example WHERE example_column = $1) SELECT DISTINCT f.*, b.baz, c.quux, b.bla AS bla_bla, now(), @x := 10 FROM foo f, baz b INNER JOIN draq ON f.b = draq.x LEFT JOIN clod c ON f.a = c.d RIGHT JOIN bock ON bock.z = c.e FULL JOIN beck ON beck.x = c.y WHERE ((f.a = $2 AND b.baz <> $3) OR ($4 < $5 AND $6 < $7) OR (f.e in ($8, $9, $10)) OR f.e BETWEEN $11 AND $12) GROUP BY f.a HAVING $13 < f.e ORDER BY b.baz DESC, c.quux, f.a NULLS FIRST LIMIT $14 OFFSET $15 "
+              0 "bort" "gabba" 1 2 2 3 1 2 3 10 20 0 50 10])))
     (testing "Locking"
-      (is (= ["SELECT DISTINCT f.*, b.baz, c.quux, b.bla AS bla_bla, now(), @x := 10 FROM foo f, baz b INNER JOIN draq ON f.b = draq.x LEFT JOIN clod c ON f.a = c.d RIGHT JOIN bock ON bock.z = c.e FULL JOIN beck ON beck.x = c.y WHERE ((f.a = ? AND b.baz <> ?) OR (? < ? AND ? < ?) OR (f.e in (?, ?, ?)) OR f.e BETWEEN ? AND ?) GROUP BY f.a HAVING ? < f.e ORDER BY b.baz DESC, c.quux, f.a NULLS FIRST LIMIT ? OFFSET ? FOR UPDATE "
-              "bort" "gabba" 1 2 2 3 1 2 3 10 20 0 50 10]
+      (is (= ["WITH cte AS (SELECT * FROM example WHERE example_column = ?) SELECT DISTINCT f.*, b.baz, c.quux, b.bla AS bla_bla, now(), @x := 10 FROM foo f, baz b INNER JOIN draq ON f.b = draq.x LEFT JOIN clod c ON f.a = c.d RIGHT JOIN bock ON bock.z = c.e FULL JOIN beck ON beck.x = c.y WHERE ((f.a = ? AND b.baz <> ?) OR (? < ? AND ? < ?) OR (f.e in (?, ?, ?)) OR f.e BETWEEN ? AND ?) GROUP BY f.a HAVING ? < f.e ORDER BY b.baz DESC, c.quux, f.a NULLS FIRST LIMIT ? OFFSET ? FOR UPDATE "
+              0 "bort" "gabba" 1 2 2 3 1 2 3 10 20 0 50 10]
              (sql/format (assoc m1 :lock {:mode :update})
                          {:param1 "gabba" :param2 2}))))))
 


### PR DESCRIPTION
This allows writing:

```
(-> (with [:foo (-> (select :*)
                    (from :baz))])
    (select :quux)
    ...)
```

instead of

```
(-> {:with [[:foo (-> (select :*)
                      (from :baz))]]}
    (select :quux)
    ...)
```