### PR TITLE
Added new helper for with/CTE clause and supporting test

### DIFF
--- a/src/honeysql/helpers.cljc
+++ b/src/honeysql/helpers.cljc
@@ -36,6 +36,9 @@
 (defn collify [x]
   (if (coll? x) x [x]))
 
+(defhelper with [m ctes]
+  (assoc m :with (collify ctes)))
+
 (defhelper select [m fields]
   (assoc m :select (collify fields)))
 


### PR DESCRIPTION
We currently use this library with one of our projects at my job and we found that it'd be useful to have a built-in helper for the SQL `with` clause, rather than manually constructing a query string using a lower level function such as `build-clause`. 

I hope my test case is sufficient; please let me know whatever else I need to do in order to send a proper PR to you folks.

Many thanks in advance,

danielle kefford