### PR TITLE
Fix using maps with different key orders in :values

### DIFF
--- a/src/honeysql/format.cljc
+++ b/src/honeysql/format.cljc
@@ -541,10 +541,11 @@
   (if (sequential? (first values))
     (str "VALUES " (comma-join (for [x values]
                                  (str "(" (comma-join (map to-sql x)) ")"))))
-    (str
-      "(" (comma-join (map to-sql (keys (first values)))) ") VALUES "
-      (comma-join (for [x values]
-                    (str "(" (comma-join (map to-sql (vals x))) ")"))))))
+    (let [cols (keys (first values))]
+      (str
+       "(" (comma-join (map to-sql cols)) ") VALUES "
+       (comma-join (for [x values]
+                     (str "(" (comma-join (map #(to-sql (get x %)) cols)) ")")))))))
 
 (defmethod format-clause :query-values [[_ query-values] _]
   (to-sql query-values))

--- a/test/honeysql/core_test.cljc
+++ b/test/honeysql/core_test.cljc
@@ -84,7 +84,13 @@
            (insert-into :foo)
            (columns :bar)
            (values [[(honeysql.format/value {:baz "my-val"})]])
-           sql/format))))
+           sql/format)))
+  (is (= ["INSERT INTO foo (a, b, c) VALUES (?, ?, ?), (?, ?, ?)"
+          "a" "b" "c" "a" "b" "c"]
+         (-> (insert-into :foo)
+             (values [(array-map :a "a" :b "b" :c "c")
+                      (hash-map :a "a" :b "b" :c "c")])
+             sql/format))))
 
 (deftest test-operators
   (testing "="


### PR DESCRIPTION
Fixes #153. Expecting every map in the :values sequence to return the values in the same order when calling `vals` was the root cause.