### PR TITLE
Specify lein version 2.7.1 in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: clojure
-lein: lein2
+lein: 2.7.1
 script: lein do check, eastwood, test


### PR DESCRIPTION
Apparently travis defaults to 2.5.1 and 2.5.1 doesn't know how to find our
tests.

Our tests all still run, so that's good.