### PR TITLE
Add ClojureScript self-host support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,8 @@
   :url "https://github.com/jkk/honeysql"
   :scm {:name "git"
         :url "https://github.com/jkk/honeysql"}
-  :dependencies [[org.clojure/clojure "1.8.0"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [net.cgrand/macrovich "0.2.0"]]
   :aliases {"test-readme" ["with-profile" "midje" "midje"]}
   :cljsbuild {:builds {:release {:source-paths ["src"]
                                  :compiler {:output-to "dist/honeysql.js"
@@ -21,6 +22,8 @@
                                          :parallel-build true
                                          :target :nodejs}}}}
   :doo {:build "test"}
+  :tach {:test-runner-ns 'honeysql.self-host-runner
+         :source-paths ["src" "test"]}
   :profiles {:midje {:dependencies [[midje "1.9.0-alpha5"]]
                      :plugins      [[lein-midje "3.2.1"]
                                     [midje-readme "1.0.9"]]
@@ -33,4 +36,5 @@
                                   [cljsbuild "1.1.6"]]
                    :plugins [[lein-cljsbuild "1.1.6"]
                              [jonase/eastwood "0.2.4"]
-                             [lein-doo "0.1.6"]]}})
+                             [lein-doo "0.1.6"]
+                             [lein-tach "0.4.0"]]}})

--- a/test/honeysql/self_host_runner.cljs
+++ b/test/honeysql/self_host_runner.cljs
@@ -1,0 +1,9 @@
+(ns honeysql.self-host-runner
+  (:require [cljs.test :as t :refer-macros [run-tests]]
+            honeysql.core-test
+            honeysql.format-test))
+
+(enable-console-print!)
+
+(run-tests 'honeysql.core-test
+           'honeysql.format-test)


### PR DESCRIPTION
This patch uses the wonderful cgrand/macrovich for supporting both JVM and
self-host ClojureScript. The library avoids destructive code changes, no
namespaces were moved.

The patch also adds a runner for self-host tests by adding the lein-tach
plugin. Tests can be launched with:

  lein tach lumo (or planck)

See the lein-tach README for details.