### PR TITLE
Add :parameterizer :none option

### DIFF
--- a/src/honeysql/format.cljc
+++ b/src/honeysql/format.cljc
@@ -51,7 +51,8 @@
 
 (def ^:private parameterizers
   {:postgresql #(str "$" (swap! *all-param-counter* inc))
-   :jdbc (constantly "?")})
+   :jdbc (constantly "?")
+   :none #(str (last @*params*))})
 
 (def ^:dynamic *quote-identifier-fn* nil)
 (def ^:dynamic *parameterizer* nil)
@@ -231,7 +232,8 @@
     :params - input parameters
     :quoting - quote style to use for identifiers; one of :ansi (PostgreSQL),
                :mysql, :sqlserver, or :oracle. Defaults to no quoting.
-    :parameterizer - style of parameter naming, one of :postgresql or :jdbc, defaults to :jdbc
+    :parameterizer - style of parameter naming, :postgresql,
+                     :jdbc or :none. Defaults to :jdbc.
     :return-param-names - when true, returns a vector of
                           [sql-str param-values param-names]"
   [sql-map & params-or-opts]
@@ -249,7 +251,7 @@
               *parameterizer* (parameterizers (or (:parameterizer opts) :jdbc))
               *allow-dashed-names?* (:allow-dashed-names? opts)]
       (let [sql-str (to-sql sql-map)]
-        (if (seq @*params*)
+        (if (and (seq @*params*) (not= :none (:parameterizer opts)))
           (if (:return-param-names opts)
             [sql-str @*params* @*param-names*]
             (into [sql-str] @*params*))

--- a/test/honeysql/format_test.cljc
+++ b/test/honeysql/format_test.cljc
@@ -136,3 +136,19 @@
                   :with [[[:bar {:columns [:spam :eggs]}]
                           {:values [[1 2] [3 4] [5 6]]}]]})
          ["WITH bar (spam, eggs) AS (VALUES (?, ?), (?, ?), (?, ?)) SELECT foo FROM bar1 UNION ALL SELECT foo FROM bar2" 1 2 3 4 5 6])))
+
+(deftest parameterizer-none
+  (testing "array parameter"
+    (is (= (format {:insert-into :foo
+                    :columns [:baz]
+                    :values [[(sql/array [1 2 3 4])]]}
+                   :parameterizer :none)
+           ["INSERT INTO foo (baz) VALUES (ARRAY[1, 2, 3, 4])"])))
+
+  (testing "union complex values"
+    (is (= (format {:union [{:select [:foo] :from [:bar1]}
+                            {:select [:foo] :from [:bar2]}]
+                    :with [[[:bar {:columns [:spam :eggs]}]
+                            {:values [[1 2] [3 4] [5 6]]}]]}
+                   :parameterizer :none)
+           ["WITH bar (spam, eggs) AS (VALUES (1, 2), (3, 4), (5, 6)) SELECT foo FROM bar1 UNION SELECT foo FROM bar2"]))))


### PR DESCRIPTION
Sometimes you want to completely skip using parameters.

Postgres, in particular, complains with cryptic "syntax error at or near "$1"
whenever query parameters cannot be used for the query. An example would be
CREATE TABLE queries where the only parameters are the VARCHAR size.

This patch adds a :none option to :parameterizer which completely skips
parameter filling (and numbering), returning the SQL string only.