### PR TITLE
Avoid wrapping QUERY with parens while formatting INSERT INTO ... QUERY

### DIFF
--- a/src/honeysql/format.cljc
+++ b/src/honeysql/format.cljc
@@ -540,7 +540,8 @@
     (str "INSERT INTO "
          (to-sql (ffirst table))
          " (" (comma-join (map to-sql (second (first table)))) ") "
-         (to-sql (second table)))
+         (binding [*subquery?* false]
+           (to-sql (second table))))
     (str "INSERT INTO " (to-sql table))))
 
 (defmethod format-clause :columns [[_ fields] _]

--- a/test/honeysql/format_test.cljc
+++ b/test/honeysql/format_test.cljc
@@ -58,7 +58,9 @@
   (is (= (format-clause (first {:insert-into [:foo {:select [:bar] :from [:baz]}]}) nil)
          "INSERT INTO foo SELECT bar FROM baz"))
   (is (= (format-clause (first {:insert-into [[:foo [:a :b :c]] {:select [:d :e :f] :from [:baz]}]}) nil)
-         "INSERT INTO foo (a, b, c) SELECT d, e, f FROM baz")))
+         "INSERT INTO foo (a, b, c) SELECT d, e, f FROM baz"))
+  (is (= (format {:insert-into [[:foo [:a :b :c]] {:select [:d :e :f] :from [:baz]}]})
+         ["INSERT INTO foo (a, b, c) SELECT d, e, f FROM baz"])))
 
 (deftest exists-test
   (is (= (format {:exists {:select [:a] :from [:foo]}})


### PR DESCRIPTION
This also adds a test using honeysql.format/format for an existing
format-clause test case for :insert-into which encodes the previously
failing behavior.