### PR TITLE
Add Deps Versions dependency status

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SQL as Clojure data structures. Build queries programmatically -- even at runtim
 ## Build
 
 [![Build Status](https://travis-ci.org/jkk/honeysql.svg?branch=master)](https://travis-ci.org/jkk/honeysql)
-[![Dependencies Status](http://jarkeeper.com/jkk/honeysql/status.svg)](http://jarkeeper.com/jkk/honeysql)
+[![Dependencies Status](https://versions.deps.co/jkk/honeysql/status.svg)](https://versions.deps.co/jkk/honeysql)
 
 ## Leiningen Coordinates
 


### PR DESCRIPTION
I noticed in the logs for Deps Versions that there was an error thrown trying to load https://versions.deps.co/jkk/honeysql a few weeks ago. I think I've resolved that error now, so I'm providing a PR. If this wasn't a maintainer checking this, and you don't want to switch, feel free to close this.