### PR TITLE
Remove nil predicate from :and

### DIFF
--- a/src/honeysql/format.cljc
+++ b/src/honeysql/format.cljc
@@ -423,9 +423,11 @@
         "not" (str "NOT " (format-predicate* (first args)))
 
         ("and" "or" "xor")
-        (paren-wrap
-         (string/join (str " " (string/upper-case op-name) " ")
-                      (map format-predicate* args)))
+        (->> args
+             (remove nil?)
+             (map format-predicate*)
+             (string/join (str " " (string/upper-case op-name) " "))
+             (paren-wrap))
 
         "exists"
         (str "EXISTS " (to-sql (first args)))

--- a/src/honeysql/helpers.cljc
+++ b/src/honeysql/helpers.cljc
@@ -84,7 +84,7 @@
     [m pred logic-op]))
 
 (defn where [& args]
-  (let [[m pred] (prep-where (remove nil? args))]
+  (let [[m pred] (prep-where args)]
     (if (nil? pred)
       m
       (assoc m :where pred))))

--- a/test/honeysql/format_test.cljc
+++ b/test/honeysql/format_test.cljc
@@ -168,3 +168,9 @@
                             {:values [[1 2] [3 4] [5 6]]}]]}
                    :parameterizer :none)
            ["WITH bar (spam, eggs) AS (VALUES (1, 2), (3, 4), (5, 6)) SELECT foo FROM bar1 UNION SELECT foo FROM bar2"]))))
+
+(deftest where-and
+  (testing "should ignore a nil predicate"
+    (is (= (format {:where [:and [:= :foo "foo"] [:= :bar "bar"] nil]}
+                   :parameterizer :postgresql)
+           ["WHERE (foo = $1 AND bar = $2)" "foo" "bar"]))))


### PR DESCRIPTION
Related to #203,#204

Maybe removing `nil` inside `format` is better than in the helper?

If you choose this, please close this without merge #206