### PR TITLE
Add package.json for npm deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ pom.xml*
 .nrepl-port
 bin
 test/readme.clj
+/node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
+dist: trusty
+sudo: required
 language: clojure
+
+cache:
+  directories:
+    - $HOME/.npm
+    - $TRAVIS_BUILD_DIR/.cache
+    - $TRAVIS_BUILD_DIR/node_modules
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y leiningen npm nodejs-legacy
-  - sudo npm install -g lumo-cljs
+  - sudo apt-get install -y leiningen
+  - nvm install --lts && nvm use --lts && npm install
+  - command -v npm
+  - npm install lumo-cljs -g
 
 install:
   - jdk_switcher use openjdk8

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@honeysql/honeysql",
+  "version": "0.9.1",
+  "license": "EPL-1.0",
+  "homepage": "https://github.com/jkk/honeysql",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jkk/honeysql"
+  },
+  "contributors": [
+    {
+      "name": "Michael Blume",
+      "email": "blume.mike@gmail.com"
+    }
+  ],
+  "files": [
+    "src/*"
+  ],
+  "directories": {
+    "lib": "src"
+  },
+  "dependencies": {
+    "macrovich": "0.2.1-SNAPSHOT"
+  }
+}


### PR DESCRIPTION
This adds the necessary file that the maintainer needs in order to:
    
     npm publish

I decided to scope the package (same as a group in maven) so that things like
honeysql-postgres can use the same. You can see the tarball produced with:

    npm pack
    tar -xvlf honeysql-honeysql-v0.9.1.tgz

I am not including the `data_reader.clj` file at the moment because I haven't
actually had any problem not having it in `lumo` (admittedly I am not probably
noticing what the printing out looks like).