### PR TITLE
Add Inlinable protocol for more sensible stringification of inline values

### DIFF
--- a/src/honeysql/types.cljc
+++ b/src/honeysql/types.cljc
@@ -61,6 +61,9 @@
 
 (defrecord SqlInline [value])
 
+(defprotocol Inlinable
+  (inline-str [x]))
+
 (defn inline
   "Prevents parameterization"
   [value]

--- a/test/honeysql/format_test.cljc
+++ b/test/honeysql/format_test.cljc
@@ -214,3 +214,9 @@
               :join [[:table2 :t2] [:= :t1.fk :t2.id]]
               :where [:= :t1.bar 42]}
              (format :quoting :mysql)))))
+
+(deftest inlined-values-are-stringified-correctly
+  (is (= ["SELECT foo, bar, NULL"]
+         (format {:select [(honeysql.core/inline "foo")
+                           (honeysql.core/inline :bar)
+                           (honeysql.core/inline nil)]}))))


### PR DESCRIPTION
The `SqlInline` record currently implements the `ToSql/to-sql` method by branching on the whether it is `nil` or not, and calling `str` on any non-nil value. Branching on type is not extensible and leads to suboptimal results (e.g. outputted SQL code represents inlined keywords with a starting colon).

My PR improves this by creating an new protocol `Inlinable` with an `inline-str` method which determines the stringification-behavior of inlined values by dispatching on their type.

It includes built-in implementations for `nil` and keywords, and a catch-all solution using `(str ...)`. It can also be extended by the user, so he can represent things like vectors in a way that suits his SQL flavor.

This PR fixes #224