### PR TITLE
The "AS" alias is no longer split before quoting

### DIFF
--- a/src/honeysql/format.cljc
+++ b/src/honeysql/format.cljc
@@ -351,14 +351,13 @@
     ;; alias
     (do
       (assert (= 2 (count x)) (str "Alias should have two parts" x))
-      (str (to-sql (first x))
-           ; Omit AS in FROM, JOIN, etc. - Oracle doesn't allow it
-           (if (= :select *clause*)
-             " AS "
-             " ")
-           (if (string? (second x))
-             (quote-identifier (second x))
-             (to-sql (second x)))))))
+      (let [[target alias] x]
+        (str (to-sql target)
+             ; Omit AS in FROM, JOIN, etc. - Oracle doesn't allow it
+             (if (= :select *clause*) " AS " " ")
+             (if (or (string? alias) (keyword? alias) (symbol? alias))
+               (quote-identifier alias :split false)
+               (to-sql alias)))))))
 
 (extend-protocol types/Inlinable
   #?(:clj clojure.lang.Keyword

--- a/test/honeysql/format_test.cljc
+++ b/test/honeysql/format_test.cljc
@@ -37,6 +37,14 @@
   (is (= (quote-identifier :foo/bar) "foo/bar"))
   (is (= (quote-identifier :foo/bar :style :ansi) "\"foo/bar\"")))
 
+(deftest alias-splitting
+  (is (= ["SELECT `aa`.`c` AS `a.c`, `bb`.`c` AS `b.c`, `cc`.`c` AS `c.c`"]
+         (format {:select [[:aa.c "a.c"]
+                           [:bb.c :b.c]
+                           [:cc.c 'c.c]]}
+                 :quoting :mysql))
+      "aliases containing \".\" are quoted as necessary but not split"))
+
 (deftest test-cte
   (is (= (format-clause
           (first {:with [[:query {:select [:foo] :from [:bar]}]]}) nil)


### PR DESCRIPTION
Fixes #216.

:wave: Happy to change the little things if needed.