### PR TITLE
Fix a typo in the Extensibility section

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ To teach `honeysql` how to handle your datatype you need to implement [`honeysql
 ;; results in => "where :some_column > ()"
 
 ;; we can teach honeysql about it:
-(extend-protocol honeysql.format.ToSql
+(extend-protocol honeysql.format/ToSql
   MyDateWrapper
   (to-sql [v] (to-sql (date/to-sql-timestamp v))))
 


### PR DESCRIPTION
The current version doesn't work and returns a non-obvious error message:

```
interface honeysql.format.ToSql is not a protocol
```