### PR TITLE
Bump midje version so tests run w/ Java 11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
   :doo {:build "test"}
   :tach {:test-runner-ns 'honeysql.self-host-runner
          :source-paths ["src" "test"]}
-  :profiles {:midje {:dependencies [[midje "1.9.1"]]
+  :profiles {:midje {:dependencies [[midje "1.9.6"]]
                      :plugins      [[lein-midje "3.2.1"]
                                     [midje-readme "1.0.9"]]
                      :midje-readme {:require "[honeysql.core :as sql]


### PR DESCRIPTION
Tests didn't work on Java 11 but updating the `midje` dep fixed that and I was able to run tests.