### PR TITLE
Bug: “Cannot determine type of empty array”

### DIFF
--- a/test/honeysql/format_test.cljc
+++ b/test/honeysql/format_test.cljc
@@ -85,6 +85,10 @@
 (deftest array-test
   (is (= (format {:insert-into :foo
                   :columns [:baz]
+                  :values [[(sql/array [])]]})
+         ["INSERT INTO foo (baz) VALUES ('{}')"]))
+  (is (= (format {:insert-into :foo
+                  :columns [:baz]
                   :values [[(sql/array [1 2 3 4])]]})
          ["INSERT INTO foo (baz) VALUES (ARRAY[?, ?, ?, ?])" 1 2 3 4]))
   (is (= (format {:insert-into :foo


### PR DESCRIPTION
Honeysql currently transforms an empty array into `ARRAY[]`. This fails because Postgres doesn’t know the type of the empty array, and Postgres emits the error “Cannot determine type of empty array”. We must change Honeysql to produce `’{}’` instead.