### PR TITLE
Don't namespace table names

### DIFF
--- a/src/honeysql/format.cljc
+++ b/src/honeysql/format.cljc
@@ -97,7 +97,7 @@
         s (cond
             (or (keyword? x) (symbol? x))
             (name-transform-fn
-              (cond *namespace-as-table?*
+              (cond (and *namespace-as-table?* (not= :from *clause*))
                     (str (when-let [n (namespace x)]
                            (str n "."))
                          (name x))


### PR DESCRIPTION
Currently, when `:namespace-as-table?` is set to `true`, namespaced tables also receive dot notation. I'm not sure about this, but I don't think this is valid?

```clojure
(sql/format {:select [:*]
             :from [:table/user]
             :where [:= :user/name "Kevin"]}
            :namespace-as-table? true)
```

Currently the output is:
```clojure
["SELECT * FROM table.user WHERE user.name = ?" "Kevin"]
```

However, I expected:
```clojure
["SELECT * FROM user WHERE user.name = ?" "Kevin"]
```

Maybe this is valid SQL, however I've never seen it before.