### PR TITLE
CI improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,4 +25,4 @@ jobs:
           key: honeysql-{{ checksum "deps.edn" }}
       - run:
           name: Run all the tests
-          command: sh run-tests.sh all
+          command: ./run-tests.sh all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Clojure CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -18,7 +18,9 @@ jobs:
         uses: DeLaGuardo/setup-clojure@master
         with:
           tools-deps: '1.10.3.839'
+      - name: Lint test script
+        run: shellcheck run-tests.sh
       - name: Run Tests
-        run: sh run-tests.sh all
+        run: ./run-tests.sh all
       - name: Check cljdoc.edn
         run: curl -fsSL https://raw.githubusercontent.com/cljdoc/cljdoc/master/script/verify-cljdoc-edn | bash -s doc/cljdoc.edn

--- a/deps.edn
+++ b/deps.edn
@@ -15,8 +15,8 @@
                 :main-opts ["-m" "cljs-test-runner.main"]}
   :readme {:extra-deps {seancorfield/readme {:mvn/version "1.0.16"}}
            :main-opts ["-m" "seancorfield.readme"]}
-  :eastwood {:extra-deps {jonase/eastwood {:mvn/version "0.4.2"}}
-             :main-opts ["-m" "eastwood.lint" "{:source-paths,[\"src\"]}"]}
+  :eastwood {:extra-deps {jonase/eastwood {:mvn/version "0.5.1"}}
+             :main-opts ["-m" "eastwood.lint" "{}"]}
   :jar {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.0.216"}}
         :exec-fn hf.depstar/jar
         :exec-args {:jar "honeysql.jar" :sync-pom true}}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 echo ==== Test README.md ==== && clojure -M:readme && \
-  echo ==== Lint Source ==== && clojure -M:eastwood && \
+  echo ==== Lint Source ==== && clojure -M:test:eastwood && \
   echo ==== Test ClojureScript ==== && clojure -M:test:cljs-runner
 
 if test $? -eq 0

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -Eexo pipefail
 
 echo ==== Test README.md ==== && clojure -M:readme && \
   echo ==== Lint Source ==== && clojure -M:test:eastwood && \

--- a/src/honey/sql/helpers.cljc
+++ b/src/honey/sql/helpers.cljc
@@ -116,6 +116,7 @@
   a column:
 
   (add-column :name [:varchar 32] [:not nil])"
+  {:arglists '([_cxt & col-elems])}
   [& col-elems]
   (generic :add-column col-elems))
 
@@ -123,7 +124,7 @@
   "Takes a single column name (use with `alter-table`).
 
   (alter-table :foo (drop-column :bar))"
-  {:arglists '([col])}
+  {:arglists '([col] [_ctx col])}
   [& args]
   (generic-1 :drop-column args))
 
@@ -140,7 +141,7 @@
   new name to which it should be renamed:
 
   (rename-column :name :full-name)"
-  {:arglists '([old-col new-col])}
+  {:arglists '([_ctx old-col new-col])}
   [& args]
   (generic :rename-column args))
 
@@ -151,7 +152,7 @@
   (add-index :unique :name-key :first-name :last-name)
 
   Produces: UNIQUE name_key(first_name, last_name)"
-  {:arglist '([& index-elems])}
+  {:arglists '([& index-elems])}
   [& args]
   (generic :add-index args))
 
@@ -169,7 +170,7 @@
   (alter-table :foo (rename-table :bar))
 
   Produces: ALTER TABLE foo RENAME TO bar"
-  {:arglist '([new-table])}
+  {:arglists '([_ctx new-table])}
   [& args]
   (generic-1 :rename-table args))
 
@@ -189,7 +190,7 @@
 
   (create-table-as :foo)
   (create-table-as :foo :if-not-exists)"
-  {:arglists '([table] [table if-not-exists])}
+  {:arglists '([table] [table if-not-exists & directives])}
   [& args]
   (generic :create-table-as args))
 
@@ -219,7 +220,7 @@
   collection of column descriptions (mostly for
   compatibility with nilenso/honeysql-postgres
   which used to be needed for DDL)."
-  {:arglists '([& col-specs] [col-spec-coll])}
+  {:arglists '([_ctx & col-specs] [_ctx col-spec-coll])}
   [& args]
   ;; special case so (with-columns [[:col-1 :definition] [:col-2 :definition]])
   ;; also works in addition to (with-columns [:col-1 :definition] [:col-2 :definition])
@@ -245,7 +246,7 @@
   (-> (create-materialized-view :cities)
       (select :*) (from :city))
       (with-data true)"
-  {:arglists '([view])}
+  {:arglists '([view & directives])}
   [& args]
   (generic :create-materialized-view args))
 
@@ -273,7 +274,7 @@
 
 (defn refresh-materialized-view
   "Accepts a materialied view name to refresh."
-  {:arglists '([view])}
+  {:arglists '([view] [directive view])}
   [& views]
   (generic :refresh-materialized-view views))
 
@@ -372,14 +373,14 @@
 
 (defn into
   "Accepts table name, optionally followed a database name."
-  {:arglist '([table] [table dbname])}
+  {:arglists '([_ctx table] [_ctx table dbname])}
   [& args]
   (generic :into args))
 
 (defn bulk-collect-into
   "Accepts a variable name, optionally followed by a limit
   expression."
-  {:arglist '([varname] [varname n])}
+  {:arglists '([_ctx varname] [_ctx varname n])}
   [& args]
   (generic :bulk-collect-into args))
 
@@ -460,7 +461,7 @@
       (set {:a 1 :b nil}))
 
   Produces: UPDATE foo SET a = ?, b = NULL"
-  {:arglists '([col-set-map])}
+  {:arglists '([_ctx col-set-map])}
   [& args]
   (generic-1 :set args))
 
@@ -710,7 +711,7 @@
   `LIMIT 20,10` is equivalent to `LIMIT 10 OFFSET 20`
 
   (-> (limit 10) (offset 20))"
-  {:arglists '([limit])}
+  {:arglists '([_ctx limit])}
   [& args]
   (generic-1 :limit args))
 
@@ -721,7 +722,7 @@
 
   Produces: OFFSET ?
   Parameters: 10"
-  {:arglists '([offset])}
+  {:arglists '([_ctx offset])}
   [& args]
   (generic-1 :offset args))
 
@@ -732,14 +733,14 @@
 
   Produces: FETCH ? ONLY
   Parameters: 10"
-  {:arglists '([offset])}
+  {:arglists '([_ctx offset])}
   [& args]
   (generic-1 :offset args))
 
 (defn for
   "Accepts a lock strength, optionally followed by one or
   more table names, optionally followed by a qualifier."
-  {:arglists '([lock-strength table* qualifier*])}
+  {:arglists '([_ctx lock-strength table* qualifier*])}
   [& args]
   (generic-1 :for args))
 
@@ -748,7 +749,7 @@
 
   It will accept the same type of syntax as `for` even
   though MySQL's `lock` clause is less powerful."
-  {:arglists '([lock-mode])}
+  {:arglists '([_ctx lock-mode])}
   [& args]
   (generic-1 :lock args))
 
@@ -765,26 +766,26 @@
 
   Produces: INSERT INTO foo (id, name) VALUES (?, ?), (?, ?)
   Parameters: 1 \"John\" 2 \"Fred\""
-  {:arglists '([row-value-coll])}
+  {:arglists '([_ctx row-value-coll])}
   [& args]
   (generic-1 :values args))
 
 (defn on-conflict
   "Accepts zero or more SQL entities (keywords or symbols),
   optionally followed by a single SQL clause (hash map)."
-  {:arglists '([column* where-clause])}
+  {:arglists '([column*] [_ctx & columns+where-clause])}
   [& args]
   (generic :on-conflict args))
 
 (defn on-constraint
   "Accepts a single constraint name."
-  {:arglists '([constraint])}
+  {:arglists '([constraint] [_ctx constraint])}
   [& args]
   (generic-1 :on-constraint args))
 
 (defn do-nothing
   "Called with no arguments, produces DO NOTHING"
-  {:arglists '([])}
+  {:arglists '([_ctx])}
   [& args]
   (generic :do-nothing args))
 
@@ -794,14 +795,14 @@
   by a `WHERE` clause. Can also accept a single hash map
   with a `:fields` entry specifying the columns to update
   and a `:where` entry specifying the `WHERE` clause."
-  {:arglists '([field-where-map] [column-value-map] [column* opt-where-clause])}
+  {:arglists '([_ctx field-where-map] [_ctx column-value-map] [_ctx column* opt-where-clause])}
   [& args]
   (generic :do-update-set args))
 
 (defn on-duplicate-key-update
   "MySQL's upsert facility. Accepts a hash map of
   column/value pairs to be updated (like `set` does)."
-  {:arglists '([column-value-map])}
+  {:arglists '([_ctx column-value-map])}
   [& args]
   (generic :on-duplicate-key-update args))
 
@@ -817,7 +818,7 @@
 
 (defn with-data
   "Accepts a Boolean determining WITH DATA vs WITH NO DATA."
-  {:arglists '([data?])}
+  {:arglists '([_ctx data?])}
   [& args]
   (generic-1 :with-data args))
 
@@ -854,7 +855,7 @@
   Produces:
   LATERAL (SELECT * FROM foo)
   LATERAL CALC_VALUE(bar)"
-  {:arglists '([clause-or-expression])}
+  {:arglists '([_ctx clause-or-expression])}
   [& args]
   (c/into [:lateral] args))
 

--- a/test/honey/sql/helpers_test.cljc
+++ b/test/honey/sql/helpers_test.cljc
@@ -575,15 +575,15 @@
                            [:id :int :unsigned :auto-increment]
                            [:name [:varchar 50] [:not nil]])))
          ["CREATE TABLE IF NOT EXISTS films (id INT UNSIGNED AUTO_INCREMENT, name VARCHAR(50) NOT NULL)"]))
-  (is (= (sql/format (-> {:create-table :films
-                          :with-columns
-                          [[:id :int :unsigned :auto-increment]
-                           [:name [:varchar 50] [:not nil]]]}))
+  (is (= (sql/format {:create-table :films
+                      :with-columns
+                      [[:id :int :unsigned :auto-increment]
+                       [:name [:varchar 50] [:not nil]]]})
          ["CREATE TABLE films (id INT UNSIGNED AUTO_INCREMENT, name VARCHAR(50) NOT NULL)"]))
-  (is (= (sql/format (-> {:create-table [:films :if-not-exists]
-                          :with-columns
-                          [[:id :int :unsigned :auto-increment]
-                           [:name [:varchar 50] [:not nil]]]}))
+  (is (= (sql/format {:create-table [:films :if-not-exists]
+                      :with-columns
+                      [[:id :int :unsigned :auto-increment]
+                       [:name [:varchar 50] [:not nil]]]})
          ["CREATE TABLE IF NOT EXISTS films (id INT UNSIGNED AUTO_INCREMENT, name VARCHAR(50) NOT NULL)"]))
   (is (= (sql/format {:drop-table :foo})
          ["DROP TABLE foo"]))


### PR DESCRIPTION
These changes have in common that they intend to run tests and linting as nicely as possible.

Commit summary:

* Eastwood: also lint tests
* Make run-tests.sh a bit more robust
  * See e.g. https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
  * The `u` option is intentionally left out (as the script has some dynamism).
* Remove some redundant `->`s
* ~Correct various :arglists~
  * Often, these functions assume a "context" coming from a `->` call.
  * This context should be reflected in the :arglists - otherwise they stop being truthful and various tooling will display incorrect information.
  * This allows the newly enabled Eastwood linting to pass.

I checked in my fork that both GH Actions and Circle remain green.

Cheers - V