### PR TITLE
Test code blocks in docs with test-doc-blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ From Clojure:
 From ClojureScript, we don't have `:refer :all`. If we want to use `:refer`, we have no choice but to be specific:
 <!-- {:test-doc-blocks/reader-cond :cljs} -->
 ```Clojure
+(refer-clojure :exclude '[filter for group-by into partition-by set update])
 (require '[honey.sql :as sql]
          '[honey.sql.helpers :refer [select select-distinct from
                                      join left-join right-join
                                      where for group-by having union
                                      order-by limit offset values columns
-                                     insert-into set composite
+                                     update insert-into set composite
                                      delete delete-from truncate] :as h]
          '[clojure.core :as c])
 ```
@@ -368,7 +369,7 @@ VALUES (?, (?, ?)), (?, (?, ?))
 Updates are possible too:
 
 ```clojure
-(-> (h/update :films)
+(-> (update :films)
     (set {:kind "dramatic"
            :watched [:+ :watched 1]})
     (where [:= :kind "drama"])
@@ -655,7 +656,7 @@ If `<table(s)>` and `<qualifier>` are both omitted, you may also omit the `[`..`
 (-> (select :foo.a)
     (from :foo)
     (where [:= :foo.a "baz"])
-    (h/for :update)
+    (for :update)
     (sql/format))
 => ["SELECT foo.a FROM foo WHERE foo.a = ? FOR UPDATE" "baz"]
 ```

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ for copying and pasting directly into your SQL tool of choice!
 
 ## Note on code samples
 
-All sample code in this README is automatically run as a unit test using
-[seancorfield/readme](https://github.com/seancorfield/readme).
+Sample code in this documentation is verified via
+[lread/test-doc-blocks](https://github.com/lread/test-doc-blocks).
 
 Some of these samples show pretty-printed SQL: HoneySQL 2.x supports `:pretty true` which inserts newlines between clauses in the generated SQL strings.
 
@@ -37,6 +37,8 @@ HoneySQL 1.x will continue to get critical security fixes but otherwise should b
 
 ## Usage
 
+From Clojure:
+<!-- {:test-doc-blocks/reader-cond :clj} -->
 ```clojure
 (refer-clojure :exclude '[filter for group-by into partition-by set update])
 (require '[honey.sql :as sql]
@@ -48,6 +50,19 @@ HoneySQL 1.x will continue to get critical security fixes but otherwise should b
          ;; helpers that you want to use!
          '[honey.sql.helpers :refer :all :as h]
          ;; so we can still get at clojure.core functions:
+         '[clojure.core :as c])
+```
+
+From ClojureScript, we don't have `:refer :all`. If we want to use `:refer`, we have no choice but to be specific:
+<!-- {:test-doc-blocks/reader-cond :cljs} -->
+```Clojure
+(require '[honey.sql :as sql]
+         '[honey.sql.helpers :refer [select select-distinct from
+                                     join left-join right-join
+                                     where for group-by having union
+                                     order-by limit offset values columns
+                                     insert-into set composite
+                                     delete delete-from truncate] :as h]
          '[clojure.core :as c])
 ```
 
@@ -78,7 +93,8 @@ HoneySQL is a relatively "pure" library, it does not manage your JDBC connection
 or run queries for you, it simply generates SQL strings. You can then pass them
 to a JDBC library, such as [`next.jdbc`](https://github.com/seancorfield/next-jdbc):
 
-```clj
+<!-- :test-doc-blocks/skip -->
+```clojure
 (jdbc/execute! conn (sql/format sqlmap))
 ```
 
@@ -543,9 +559,9 @@ These can be combined to allow more fine-grained control over SQL generation:
 ```
 ```clojure
 call-qualify-map
-=> '{:where [:and [:= :a [:param :baz]] [:= :b [:inline 42]]]
-     :from (:foo)
-     :select [[[:foo :bar]] [[:raw "@var := foo.bar"]]]}
+=> {:where [:and [:= :a [:param :baz]] [:= :b [:inline 42]]]
+    :from (:foo)
+    :select [[[:foo :bar]] [[:raw "@var := foo.bar"]]]}
 ```
 ```clojure
 (sql/format call-qualify-map {:params {:baz "BAZ"}})
@@ -639,7 +655,7 @@ If `<table(s)>` and `<qualifier>` are both omitted, you may also omit the `[`..`
 (-> (select :foo.a)
     (from :foo)
     (where [:= :foo.a "baz"])
-    (for :update)
+    (h/for :update)
     (sql/format))
 => ["SELECT foo.a FROM foo WHERE foo.a = ? FOR UPDATE" "baz"]
 ```
@@ -730,7 +746,9 @@ OFFSET ?
 ```
 ```clojure
 ;; Printable and readable
-(= big-complicated-map (read-string (pr-str big-complicated-map)))
+(require '[clojure.edn :as edn])
+
+(= big-complicated-map (edn/read-string (pr-str big-complicated-map)))
 => true
 ```
 

--- a/build.clj
+++ b/build.clj
@@ -9,9 +9,11 @@
   For more information, run:
 
   clojure -A:deps -T:build help/doc"
-  (:require [clojure.tools.build.api :as b]
+  (:require [babashka.fs :as fs]
+            [clojure.tools.build.api :as b]
             [clojure.tools.deps.alpha :as t]
-            [deps-deploy.deps-deploy :as dd]))
+            [deps-deploy.deps-deploy :as dd]
+            [lread.test-doc-blocks :as tdb]))
 
 (def lib 'com.github.seancorfield/honeysql)
 (def version (format "2.0.%s" (b/git-count-revs nil)))
@@ -51,7 +53,22 @@
     (when-not (zero? exit)
       (throw (ex-info (str "Task failed for: " aliases) {})))))
 
-(defn readme "Run the README tests." [opts] (run-task [:readme]) opts)
+(defn gen-doc-tests "Generate tests from doc code blocks" [opts]
+  (let [docs ["README.md"
+              "doc/clause-reference.md"
+              "doc/differences-from-1-x.md"
+              "doc/extending-honeysql.md"
+              "doc/general-reference.md"
+              "doc/getting-started.md"
+              "doc/postgresql.md"
+              "doc/special-syntax.md"]
+        updated-docs (fs/modified-since "target/test-doc-blocks" (conj docs "build.clj" "deps.edn"))]
+    (if (seq updated-docs)
+      (do
+        (println "gen-doc-tests: Regenerating: found newer:" (mapv str updated-docs))
+        (tdb/gen-tests {:docs docs}))
+      (println "gen-doc-tests: Tests already generated")))
+  opts)
 
 (defn eastwood "Run Eastwood." [opts] (run-task [:eastwood]) opts)
 
@@ -67,9 +84,30 @@
   (run-task (into [:test] aliases))
   opts)
 
+(defn run-doc-tests
+  "Run generated doc tests.
+
+  Optionally specify :platform:
+  :1.9 -- test against Clojure 1.9 (the default)
+  :1.10 -- test against Clojure 1.10.3
+  :master -- test against Clojure 1.11 master snapshot
+  :cljs -- test against ClojureScript"
+  [{:keys [platform] :or {platform :1.9} :as opts}]
+  (gen-doc-tests opts)
+  (let [aliases (case platform
+                  :cljs [platform :test-doc :test-doc-cljs]
+                  [platform :runner :test-doc :test-doc-clj])]
+    (run-task aliases))
+  opts)
+
 (defn ci "Run the CI pipeline of tests (and build the JAR)." [opts]
   (-> opts
-      (readme)
+      (clean)
+      (as-> opts
+          (reduce (fn [opts platform]
+                    (run-doc-tests (assoc opts :platform platform)))
+                  opts
+                  [:cljs :1.9 :1.10 :master]))
       (eastwood)
       (as-> opts
             (reduce (fn [opts alias]

--- a/build.clj
+++ b/build.clj
@@ -10,10 +10,8 @@
 
   clojure -A:deps -T:build help/doc"
 
-  (:require [babashka.fs :as fs]
-            [clojure.tools.build.api :as b]
-            [org.corfield.build :as bb]
-            [lread.test-doc-blocks :as tdb]))
+  (:require [clojure.tools.build.api :as b]
+            [org.corfield.build :as bb]))
 
 (def lib 'com.github.seancorfield/honeysql)
 (def version (format "2.0.%s" (b/git-count-revs nil)))
@@ -21,33 +19,8 @@
 (defn eastwood "Run Eastwood." [opts]
   (-> opts (bb/run-task [:eastwood])))
 
-(defn gen-doc-tests "Generate tests from doc code blocks" [opts]
-  (let [target "target/test-doc-blocks"
-        success-marker (fs/file target "SUCCESS")
-        docs ["README.md"
-              "doc/clause-reference.md"
-              "doc/differences-from-1-x.md"
-              "doc/extending-honeysql.md"
-              "doc/general-reference.md"
-              "doc/getting-started.md"
-              "doc/postgresql.md"
-              "doc/special-syntax.md"]
-        regen-reason (if (not (fs/exists? success-marker))
-                       "a previous successful gen result not found"
-                       (let [newer-thans (fs/modified-since target
-                                                            (concat docs
-                                                                    ["build.clj" "deps.edn"]
-                                                                    (fs/glob "src" "**/*.*")))]
-                         (when (seq newer-thans)
-                           (str "found files newer than last gen: " (mapv str newer-thans)))))]
-    (if regen-reason
-      (do
-        (fs/delete-if-exists success-marker)
-        (println "gen-doc-tests: Regenerating:" regen-reason)
-        (tdb/gen-tests {:docs docs})
-        (spit success-marker "SUCCESS"))
-      (println "gen-doc-tests: Tests already successfully generated")))
-  opts)
+(defn gen-doc-tests "Generate tests from doc code blocks." [opts]
+  (-> opts (bb/run-task [:gen-doc-tests])))
 
 (defn run-doc-tests
   "Generate and run doc tests.

--- a/build/honey/gen_doc_tests.clj
+++ b/build/honey/gen_doc_tests.clj
@@ -1,0 +1,31 @@
+(ns honey.gen-doc-tests
+  (:require [babashka.fs :as fs]
+            [lread.test-doc-blocks :as tdb]))
+
+(defn -main [& _args]
+  (let [target "target/test-doc-blocks"
+        success-marker (fs/file target "SUCCESS")
+        docs ["README.md"
+              "doc/clause-reference.md"
+              "doc/differences-from-1-x.md"
+              "doc/extending-honeysql.md"
+              "doc/general-reference.md"
+              "doc/getting-started.md"
+              "doc/postgresql.md"
+              "doc/special-syntax.md"]
+        regen-reason (if (not (fs/exists? success-marker))
+                       "a previous successful gen result not found"
+                       (let [newer-thans (fs/modified-since target
+                                                            (concat docs
+                                                                    ["build.clj" "deps.edn"]
+                                                                    (fs/glob "build" "**/*.*")
+                                                                    (fs/glob "src" "**/*.*")))]
+                         (when (seq newer-thans)
+                           (str "found files newer than last gen: " (mapv str newer-thans)))))]
+    (if regen-reason
+      (do
+        (fs/delete-if-exists success-marker)
+        (println "gen-doc-tests: Regenerating:" regen-reason)
+        (tdb/gen-tests {:docs docs})
+        (spit success-marker "SUCCESS"))
+      (println "gen-doc-tests: Tests already successfully generated"))))

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,9 @@
  :deps {org.clojure/clojure {:mvn/version "1.9.0"}}
  :aliases
  {;; for help: clojure -A:deps -T:build help/doc
-  :build {:deps {io.github.clojure/tools.build {:git/tag "v0.1.9" :git/sha "6736c83"}
+  :build {:deps {babashka/fs {:mvn/version "0.0.5"}
+                 com.github.lread/test-doc-blocks {:mvn/version "1.0.137-alpha"}
+                 io.github.clojure/tools.build {:git/tag "v0.1.9" :git/sha "6736c83"}
                  io.github.slipset/deps-deploy {:sha "b4359c5d67ca002d9ed0c4b41b710d7e5a82e3bf"}}
           :ns-default build}
 
@@ -13,18 +15,25 @@
   :master {:override-deps {org.clojure/clojure {:mvn/version "1.11.1-master-SNAPSHOT"}}}
 
   ;; running tests/checks of various kinds:
-  :test ; can also run clojure -X:test
-  {:extra-paths ["test"]
-   :extra-deps {io.github.cognitect-labs/test-runner
-                {:git/tag "v0.4.0" :git/sha "334f2e2"}}
-   :exec-fn cognitect.test-runner.api/test}
 
-  ;; various "runners" for tests/CI:
-  :runner
-  {:main-opts ["-m" "cognitect.test-runner"]}
+  :test {:extra-paths ["test"]}
+
+  :runner ; can also run clojure -X:test
+  {:extra-deps  {io.github.cognitect-labs/test-runner
+                 {:git/tag "v0.4.0" :git/sha "334f2e2"}}
+   :main-opts ["-m" "cognitect.test-runner"]
+   :exec-fn     cognitect.test-runner.api/test}
+
+;; various "runners" for tests/CI:
   :cljs {:extra-deps {olical/cljs-test-runner {:mvn/version "3.8.0"}}
          :main-opts ["-m" "cljs-test-runner.main"]}
-  :readme {:extra-deps {seancorfield/readme {:mvn/version "1.0.16"}}
-           :main-opts ["-m" "seancorfield.readme"]}
+
+  :test-doc {:extra-paths ["target/test-doc-blocks/test"]}
+  :test-doc-clj {:main-opts ["-m" "cognitect.test-runner"
+                             "-d" "target/test-doc-blocks/test"]}
+  :test-doc-cljs {:main-opts ["-m" "cljs-test-runner.main"
+                              "-c" "{:warnings,{:single-segment-namespace,false}}"
+                              "-d" "target/test-doc-blocks/test"]}
+
   :eastwood {:extra-deps {jonase/eastwood {:mvn/version "0.5.1"}}
              :main-opts ["-m" "eastwood.lint" "{:source-paths,[\"src\"]}"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
  :aliases
  {;; for help: clojure -A:deps -T:build help/doc
   :build {:deps {babashka/fs {:mvn/version "0.0.5"}
-                 com.github.lread/test-doc-blocks {:mvn/version "1.0.137-alpha"}
+                 com.github.lread/test-doc-blocks {:mvn/version "1.0.146-alpha"}
                  io.github.seancorfield/build-clj {:git/tag "v0.1.0" :git/sha "fe2d586"}}
           :ns-default build}
 

--- a/deps.edn
+++ b/deps.edn
@@ -3,9 +3,8 @@
  :deps {org.clojure/clojure {:mvn/version "1.9.0"}}
  :aliases
  {;; for help: clojure -A:deps -T:build help/doc
-  :build {:deps {babashka/fs {:mvn/version "0.0.5"}
-                 com.github.lread/test-doc-blocks {:mvn/version "1.0.146-alpha"}
-                 io.github.seancorfield/build-clj {:git/tag "v0.1.0" :git/sha "fe2d586"}}
+  :build {:deps {io.github.seancorfield/build-clj
+                 {:git/tag "v0.1.0" :git/sha "fe2d586"}}
           :ns-default build}
 
   ;; versions to test against:
@@ -23,6 +22,11 @@
   ;; various "runners" for tests/CI:
   :cljs {:extra-deps {olical/cljs-test-runner {:mvn/version "3.8.0"}}
          :main-opts ["-m" "cljs-test-runner.main"]}
+
+  :gen-doc-tests {:replace-paths ["build"]
+                  :extra-deps {babashka/fs {:mvn/version "0.0.5"}
+                               com.github.lread/test-doc-blocks {:mvn/version "1.0.146-alpha"}}
+                  :main-opts ["-m" "honey.gen-doc-tests"]}
 
   :test-doc {:replace-paths ["src" "target/test-doc-blocks/test"]}
   :test-doc-clj {:main-opts ["-m" "cognitect.test-runner"

--- a/doc/clause-reference.md
+++ b/doc/clause-reference.md
@@ -16,6 +16,7 @@ DDL clauses are listed first, followed by SQL clauses.
 
 The examples herein assume:
 ```clojure
+(refer-clojure :exclude '[partition-by])
 (require '[honey.sql :as sql]
          '[honey.sql.helpers :refer [select from join-by left-join join
                                      where order-by over partition-by window]])

--- a/doc/differences-from-1-x.md
+++ b/doc/differences-from-1-x.md
@@ -19,17 +19,30 @@ In addition, HoneySQL 2.x contains different namespaces so you can have both ver
 
 ### HoneySQL 1.x
 
+In `deps.edn`:
+<!-- :test-doc-blocks/skip -->
 ```clojure
-;; in deps.edn:
 honeysql {:mvn/version "1.0.461"}
 ;; or, more correctly:
 honeysql/honeysql {:mvn/version "1.0.461"}
+```
 
-;; in use:
+Required as:
+<!-- :test-doc-blocks/skip -->
+```clojure
 (ns my.project
   (:require [honeysql.core :as sql]))
+```
 
-...
+Or if in the REPL:
+<!-- :test-doc-blocks/skip -->
+```clojure
+(require '[honeysql.core :as sq])
+```
+
+In use:
+<!-- :test-doc-blocks/skip -->
+```clojure
   (sql/format {:select [:*] :from [:table] :where [:= :id 1]})
   ;;=> ["SELECT * FROM table WHERE id = ?" 1]
   (sql/format {:select [:*] :from [:table] :where [:= :id 1]} :quoting :mysql)
@@ -47,15 +60,26 @@ Supported Clojure versions: 1.7 and later.
 
 ### HoneySQL 2.x
 
+In `deps.edn`:
+<!-- :test-doc-blocks/skip -->
 ```clojure
-;; in deps.edn:
 com.github.seancorfield/honeysql {:mvn/version "2.0.783"}
+```
 
-;; in use:
+Required as:
+<!-- :test-doc-blocks/skip -->
+```clojure
 (ns my.project
   (:require [honey.sql :as sql]))
+```
 
-...
+Or if in the REPL:
+```clojure
+(require '[honey.sql :as sql])
+```
+
+In use:
+```clojure
   (sql/format {:select [:*] :from [:table] :where [:= :id 1]})
   ;;=> ["SELECT * FROM table WHERE id = ?" 1]
   (sql/format {:select [:*] :from [:table] :where [:= :id 1]} {:dialect :mysql})
@@ -158,7 +182,7 @@ it should have been a function, and in 2.x it is:
 ```clojure
 ;; 1.x: EXISTS should never have been implemented as SQL syntax: it's an operator!
 ;; (sq/format {:exists {:select [:a] :from [:foo]}})
-;;=> ["EXISTS (SELECT a FROM foo)"]
+;; -> ["EXISTS (SELECT a FROM foo)"]
 
 ;; 2.x: select function call with an alias:
 user=> (sql/format {:select [[[:exists {:select [:a] :from [:foo]}] :x]]})

--- a/doc/extending-honeysql.md
+++ b/doc/extending-honeysql.md
@@ -50,6 +50,8 @@ two arguments. You can optionally specify that an operator
 can take any number of arguments with `:variadic true`:
 
 ```clojure
+(require '[honey.sql :as sql])
+
 (sql/register-op! :<=> :variadic true)
 ;; and then use the new operator:
 (sql/format {:select [:*], :from [:table], :where [:<=> 13 :x 42]})
@@ -86,6 +88,7 @@ The formatter function will be called with:
 
 For example:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (sql/register-fn! :foo (fn [f args] ..))
 

--- a/doc/general-reference.md
+++ b/doc/general-reference.md
@@ -12,6 +12,8 @@ because `:quoted true` was specified, the literal name of an unqualified,
 single-segment keyword or symbol is used as-is and quoted:
 
 ```clojure
+(require '[honey.sql :as sql])
+
 (sql/format {:select :foo-bar} {:quoted true})
 ;;=> ["SELECT \"foo-bar\""]
 (sql/format {:select :foo-bar} {:dialect :mysql})

--- a/doc/postgresql.md
+++ b/doc/postgresql.md
@@ -20,6 +20,7 @@ HoneySQL not to do that. There are two possible approaches:
 
 The code example herein assume:
 ```clojure
+(refer-clojure :exclude '[update set])
 (require '[honey.sql :as sql]
          '[honey.sql.helpers :refer [select from where
                                      update set

--- a/doc/special-syntax.md
+++ b/doc/special-syntax.md
@@ -124,6 +124,7 @@ There are helpers for both `filter` and `within-group`. Be careful with `filter`
 since it shadows `clojure.core/filter`:
 
 ```clojure
+(refer-clojure :exclude '[filter])
 (require '[honey.sql.helpers :refer [select filter within-group from order-by where]])
 
 (sql/format (-> (select :a :b [(filter :%count.* (where :< :x 100)) :c]

--- a/doc/special-syntax.md
+++ b/doc/special-syntax.md
@@ -13,6 +13,8 @@ a sequence, and produces `ARRAY[?, ?, ..]` for the elements
 of that sequence (as SQL parameters):
 
 ```clojure
+(require '[honey.sql :as sql])
+
 (sql/format-expr [:array (range 5)])
 ;;=> ["ARRAY[?, ?, ?, ?, ?]" 0 1 2 3 4]
 ```
@@ -36,8 +38,7 @@ may be `:else` (or `'else`) to produce `ELSE`, otherwise
 
 ```clojure
 (sql/format-expr [:case [:< :a 10] "small" [:> :a 100] "big" :else "medium"])
-;;=> ["CASE WHEN a < ? THEN ? WHEN a > ? THEN ? ELSE ? END"
-;;    10 "small" 100 "big" "medium"]
+;; => ["CASE WHEN a < ? THEN ? WHEN a > ? THEN ? ELSE ? END" 10 "small" 100 "big" "medium"]
 ```
 
 ## cast
@@ -76,6 +77,7 @@ SQL entity. This is intended for use in contexts that would
 otherwise produce a sequence of SQL keywords, such as when
 constructing DDL statements.
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 [:tablespace :quux]
 ;;=> TABLESPACE QUUX
@@ -89,9 +91,9 @@ Intended to be used with regular expression patterns to
 specify the escape characters (if any).
 
 ```clojure
-(format {:select :* :from :foo
-         :where [:similar-to :foo [:escape "bar" [:inline  "*"]]]})
-;;=> ["SELECT * FROM foo WHERE foo SIMILAR TO ? ESCAPE '*'" "bar"]))))
+(sql/format {:select :* :from :foo
+             :where [:similar-to :foo [:escape "bar" [:inline  "*"]]]})
+;;=> ["SELECT * FROM foo WHERE foo SIMILAR TO ? ESCAPE '*'" "bar"]
 ```
 
 ## filter, within-group
@@ -104,34 +106,38 @@ Filter generally expects an aggregate expression and a `WHERE` clause.
 Within group generally expects an aggregate expression and an `ORDER BY` clause.
 
 ```clojure
-(format {:select [:a :b [[:filter :%count.* {:where [:< :x 100]}] :c]
-                  [[:within-group [:percentile_disc [:inline 0.25]]
-                                  {:order-by [:a]}] :inter_max]
-                  [[:within-group [:percentile_cont [:inline 0.25]]
-                                  {:order-by [:a]}] :abs_max]]
-         :from :aa})
-;; newlines added for readability:
-;;=> ["SELECT a, b, COUNT(*) FILTER (WHERE x < ?) AS c,
-;;=>          PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY a ASC) AS inter_max,
-;;=>          PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY a ASC) AS abs_max
-;;=>   FROM aa" 100]
+(sql/format {:select [:a :b [[:filter :%count.* {:where [:< :x 100]}] :c]
+                     [[:within-group [:percentile_disc [:inline 0.25]]
+                                     {:order-by [:a]}] :inter_max]
+                     [[:within-group [:percentile_cont [:inline 0.25]]
+                                     {:order-by [:a]}] :abs_max]]
+             :from :aa}
+             {:pretty true})
+;;=> ["
+SELECT a, b, COUNT(*) FILTER (WHERE x < ?) AS c, PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY a ASC) AS inter_max, PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY a ASC) AS abs_max
+FROM aa
+"
+100]
 ```
 
 There are helpers for both `filter` and `within-group`. Be careful with `filter`
 since it shadows `clojure.core/filter`:
 
 ```clojure
-(format (-> (select :a :b [(filter :%count.* (where :< :x 100)) :c]
-                    [(within-group [:percentile_disc [:inline 0.25]]
-                                   (order-by :a)) :inter_max]
-                    [(within-group [:percentile_cont [:inline 0.25]]
-                                   (order-by :a)) :abs_max])
-            (from :aa)))
-;; newlines added for readability:
-;;=> ["SELECT a, b, COUNT(*) FILTER (WHERE x < ?) AS c,
-;;=>          PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY a ASC) AS inter_max,
-;;=>          PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY a ASC) AS abs_max
-;;=>   FROM aa" 100]
+(require '[honey.sql.helpers :refer [select filter within-group from order-by where]])
+
+(sql/format (-> (select :a :b [(filter :%count.* (where :< :x 100)) :c]
+                        [(within-group [:percentile_disc [:inline 0.25]]
+                                       (order-by :a)) :inter_max]
+                        [(within-group [:percentile_cont [:inline 0.25]]
+                                       (order-by :a)) :abs_max])
+                (from :aa))
+                {:pretty true})
+;;=> ["
+SELECT a, b, COUNT(*) FILTER (WHERE x < ?) AS c, PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY a ASC) AS inter_max, PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY a ASC) AS abs_max
+FROM aa
+"
+100]
 ```
 
 ## inline
@@ -214,15 +220,15 @@ by an ordering specifier, which can be an expression or a pair of expression
 and direction (`:asc` or `:desc`):
 
 ```clojure
-(format {:select [[[:array_agg [:order-by :a [:b :desc]]]]] :from :table})
+(sql/format {:select [[[:array_agg [:order-by :a [:b :desc]]]]] :from :table})
 ;;=> ["SELECT ARRAY_AGG(a ORDER BY b DESC) FROM table"]
-(format (-> (select [[:array_agg [:order-by :a [:b :desc]]]])
+(sql/format (-> (select [[:array_agg [:order-by :a [:b :desc]]]])
                 (from :table)))
 ;;=> ["SELECT ARRAY_AGG(a ORDER BY b DESC) FROM table"]
-(format {:select [[[:string_agg :a [:order-by [:inline ","] :a]]]] :from :table})
+(sql/format {:select [[[:string_agg :a [:order-by [:inline ","] :a]]]] :from :table})
 ;;=> ["SELECT STRING_AGG(a, ',' ORDER BY a ASC) FROM table"]
-(format (-> (select [[:string_agg :a [:order-by [:inline ","] :a]]])
-            (from :table)))
+(sql/format (-> (select [[:string_agg :a [:order-by [:inline ","] :a]]])
+                (from :table)))
 ;;=> ["SELECT STRING_AGG(a, ',' ORDER BY a ASC) FROM table"]
 ```
 
@@ -285,7 +291,7 @@ parameters from them:
 (sql/format {:select [:a [[:raw ["@var := " [:inline "foo"]]]]]})
 ;;=> ["SELECT a, @var := 'foo'"]
 (sql/format {:select [:a [[:raw ["@var := " ["foo"]]]]]})
-;;=> ["SELECT a, @var := ?" "foo"]
+;;=> ["SELECT a, @var := (?)" "foo"]
 ```
 
 `:raw` is also supported as a SQL clause for the same reason.
@@ -304,6 +310,7 @@ specifications).
 If no arguments are provided, these render as just SQL
 keywords (uppercase):
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 [:foreign-key] ;=> FOREIGN KEY
 [:primary-key] ;=> PRIMARY KEY
@@ -311,6 +318,7 @@ keywords (uppercase):
 
 Otherwise, these render as regular function calls:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 [:foreign-key :a]    ;=> FOREIGN KEY(a)
 [:primary-key :x :y] ;=> PRIMARY KEY(x, y)
@@ -326,6 +334,7 @@ argument. If two or more arguments are provided, this
 renders as a SQL keyword followed by the first argument,
 followed by the rest as a regular argument list:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 [:default]              ;=> DEFAULT
 [:default 42]           ;=> DEFAULT 42
@@ -339,6 +348,7 @@ followed by the rest as a regular argument list:
 These behave like the group above except that if the
 first argument is `nil`, it is omitted:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 [:index :foo :bar :quux] ;=> INDEX foo(bar, quux)
 [:index nil :bar :quux]  ;=> INDEX(bar, quux)


### PR DESCRIPTION
Resolves #290

**Build**

New commands:
- `gen-doc-tests` - only regenerates tests if stale,
   use `clean` command to force regen
- `run-doc-tests` - calls gen-doc-tests then runs tests,
  accepts the same parameters as run-tests.
  Can specify `:platform`
    - `:cljs` - run tests under ClojureScript
    - otherwise Clojure where we can specify one of: `:1.9`
    `:1.10` `:master`

I'm not sure if my use of the `:platform` parameter jives with
your `:aliases` parameter used for `run-tests`.
Can adjust if you like.

Example usages:
```shell
clojure -T:build gen-doc-tests
clojure -T:build run-doc-tests
clojure -T:build run-doc-tests :aliases '[:cljs]'
clojure -T:build run-doc-tests :aliases '[:1.9]'
clojure -T:build run-doc-tests :aliases '[:1.10]'
clojure -T:build run-doc-tests :aliases '[:master]'
```

The `ci` command has been updated to generate and run doc tests for same
platforms as unit tests.

**Articles**

In addition to `README.md`, now testing doc blocks in all articles
under `doc` dir excepting `doc/operator-reference.md` which does not
have any runnable code blocks.

**Skipped**

Any code block that is intentionally not runnable has been marked to be
skipped via: `<!-- :test-doc-blocks/skip -->`.

**Consistency**

I noticed that some code blocks use REPL syntax:
```Clojure
user=> (+ 1 2 3)
6
```
and others use editor syntax:
```Clojure
(+ 1 2 3)
;;=> 6
```
some places also omit the comment for editor style:
```Clojure
(+ 1 2 3)
=> 6
```
All of this is just fine with test-doc-blocks.
I left the inconsistency as is, but can make a pass for consistency upon
request.

**HoneySQL state**

I noticed a code block that set the sql dialect was affecting other
tests. I simply restored the dialect to the default at the end of the
code block.

**Un-tweaked output**

Some code blocks had string output hand-tweaked for readability.
These have been adjusted to instead use `sql/format`'s `:pretty` option.
In some cases the output is not as readable as the hand-tweaked version.
I humbly suggest that perhaps `:pretty` output could perhaps be
improved (instead of having test-doc-blocks somehow adapt).

**Corrections**

There were very few code blocks that required fixing due to incorrect
output/code.  Please review the diffs carefully to make sure all is as
expected.

**ns requires adjustments**

Any specific case of `(ns my-ns (require [my-require :as a]))` is now
the REPL friendly `(require '[my-require :as a])`

Any missing required `requires` were added.

**ClojureScript :refer**

The HoneySQL docs seem to encourage the use of referred vars for
helpers. Although this has the con of overlaps with Clojure core vars,
it is also convenient for Clojure when using `:refer :all`.

ClojureScript does not support `:refer :all` and each var must be
specified in place of `:all`.

I have adjusted examples accordingly to work with both Clojure and
ClojureScript.