### PR TITLE
add support for multiple add/modify column statements

### DIFF
--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -801,7 +801,10 @@
         ")")])
 
 (defn- format-add-item [k spec]
-  [(str (sql-kw k) " " (format-single-column spec))])
+  ;; if there are several column clauses
+  (if (sequential? (first spec))
+    [(str/join ", " (map #(str (sql-kw k) " " (format-single-column %)) spec))]
+    [(str (sql-kw k) " " (format-single-column spec))]))
 
 (defn- format-rename-item [k [x y]]
   [(str (sql-kw k) " " (format-entity x) " TO " (format-entity y))])

--- a/src/honey/sql/helpers.cljc
+++ b/src/honey/sql/helpers.cljc
@@ -68,10 +68,24 @@
           (simplify-logic))
       current)))
 
+(defn- one-then-many-merge
+  "Merge for add-column.
+  The clause supports both single and multiple columns statements
+  (we keep the single case to ensure retro-compability).
+  the first add-column will add the column args directly into the key
+  and subsequent calls will transform it into a vector of column args"
+  [current args]
+  (if current
+    (if (sequential? (first current))
+      (conj current args)
+      [current args])
+    args))
+
 (def ^:private special-merges
   "Identify the conjunction merge clauses."
-  {:where  #'conjunction-merge
-   :having #'conjunction-merge})
+  {:where      #'conjunction-merge
+   :having     #'conjunction-merge
+   :add-column #'one-then-many-merge})
 
 (defn- helper-merge [data k args]
   (if-let [merge-fn (special-merges k)]

--- a/test/honey/sql/helpers_test.cljc
+++ b/test/honey/sql/helpers_test.cljc
@@ -865,3 +865,14 @@
            {:with [[:a]],
             :insert-into [[:quux [:x :y]]
                           {:select [:id], :from [:table]}]}))))
+
+(deftest issue-355-multiple-add-column-test
+  (testing "the first column clause is not wrapped into a vector (backward compatible)"
+    (is (= {:add-column [:a :string]}
+           (add-column :a :string))))
+
+  (testing "subsequent calls conj the clause into a vector"
+    (is (= {:add-column [[:a :string] [:b :string] [:c :string]]}
+           (-> {:add-column [:a :string]}
+               (add-column :b :string)
+               (add-column :c :string))))))

--- a/test/honey/sql_test.cljc
+++ b/test/honey/sql_test.cljc
@@ -820,3 +820,13 @@ ORDER BY id = ? DESC
            (format {:select :foo :from :bar
                     :offset 20}
                    {:dialect :sqlserver})))))
+
+(deftest issue-355-multiple-alter-columns-test
+  (testing "alter table add single column"
+    (is (= ["ALTER TABLE t ADD COLUMN a STRING"]
+           (format {:alter-table :t :add-column [:a :string]})))
+    (is (= ["ALTER TABLE t ADD COLUMN a STRING"]
+           (format {:alter-table :t :add-column [[:a :string]]}))))
+  (testing "alter table add multiple columns"
+    (is (= ["ALTER TABLE t ADD COLUMN a STRING, ADD COLUMN b STRING NOT NULL"]
+           (format {:alter-table :t :add-column [[:a :string] [:b :string [:not nil]]]})))))


### PR DESCRIPTION
I'm not sure if it is something wanted and if I've done it the right way (`one-then-many-merge` looks odd maybe?)
My purpose was to be backward compatible for people who rely on the current add-column DSL structure.
Addresses #355 