### PR TITLE
Allowing parameters as part of IS NULL/IS NOT NULL queries

### DIFF
--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -1256,7 +1256,9 @@
                                    (if (= := op) " IS NULL" " IS NOT NULL"))
                               (cond-> nested
                                 (as-> s (str "(" s ")")))
-                              (vector))
+                              (vector)
+                              (into p1)
+                              (into p2))
                           (-> (str s1 " " (sql-kw op) " " s2)
                               (cond-> nested
                                 (as-> s (str "(" s ")")))


### PR DESCRIPTION
My use case is with Postgres and json/jsonb operators (e.g. `[:= [:-> :jsonb-column-name "key-name"] nil]`). Currently, I need to build the keys into the query instead of using parameters.