### PR TITLE
Fix docstring of add-clause-before

### DIFF
--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -67,7 +67,7 @@
 (defn- add-clause-before
   "Low-level helper just to insert a new clause.
 
-  If the clause is already in the list, remove it."
+  If the clause is already in the list, this moves it to the end."
   [order clause before]
   (let [clauses (set order)
         order   (if (contains? clauses clause)


### PR DESCRIPTION
The result of adding a clause to a list in which the it already appears, is not to remove it from the list, but to move it to the end.