### PR TITLE
Change public-fns-have-clauses assertion to allow custom clauses

### DIFF
--- a/src/honey/sql/helpers.cljc
+++ b/src/honey/sql/helpers.cljc
@@ -1030,7 +1030,7 @@
        ;; ensure #295 stays true (all public functions have docstring):
        (assert (empty? (->> (ns-publics *ns*) (vals) (c/filter (comp not :doc meta))))))
      ;; ensure all public functions match clauses:
-     (assert (= (clojure.core/set (conj @@#'honey.sql/base-clause-order
+     (assert (= (clojure.core/set (conj @#'honey.sql/default-clause-order
                                         :composite :filter :lateral :over :within-group
                                         :upsert
                                         :generic-helper-variadic :generic-helper-unary))


### PR DESCRIPTION
Fixes #416

At the end of honey.sql.helpers there is an assert that confirms that all public functions have registered clauses. Formerly it was ensuring that the set of all public functions in the helpers namespace was identical to the set of currently valid clauses. This prevented registering new clauses before the helpers namespace was loaded.

This PR changes the assertion so that it compares against the original, unchanged set of clauses. This more accurately matches the intention of the assertion as well.