### PR TITLE
Support materialization control in WITH

### DIFF
--- a/test/honey/sql_test.cljc
+++ b/test/honey/sql_test.cljc
@@ -124,6 +124,12 @@
 (deftest test-cte
   (is (= (format {:with [[:query {:select [:foo] :from [:bar]}]]})
          ["WITH query AS (SELECT foo FROM bar)"]))
+  (is (= (format {:with [[:query {:select [:foo] :from [:bar]} :materialized]]})
+         ["WITH query AS MATERIALIZED (SELECT foo FROM bar)"]))
+  (is (= (format {:with [[:query {:select [:foo] :from [:bar]} :not-materialized]]})
+         ["WITH query AS NOT MATERIALIZED (SELECT foo FROM bar)"]))
+  (is (= (format {:with [[:query {:select [:foo] :from [:bar]} :unknown]]})
+         ["WITH query AS (SELECT foo FROM bar)"]))
   (is (= (format {:with [[:query1 {:select [:foo] :from [:bar]}]
                          [:query2 {:select [:bar] :from [:quux]}]]
                   :select [:query1.id :query2.name]


### PR DESCRIPTION
Adds an optional third value to `with` vectors, which can be the
following:

* `:materialized` -> SQL is `WITH cte AS MATERIALIZED (...)`
* `:not-materialized` -> SQL is `WITH cte AS NOT MATERIALIZED (...)`
* omitted or anything else -> SQL is `WITH cte AS (...)`

Note that materialization control is not available on WITH RECURSIVE
CTEs, so `format-with` was modified to take a third argument that
returns the `AS ...` separator, which is constantly `"AS"` for WITH
RECURSIVE, and obeys the aforementioned rules for non-recursive CTEs.

Resolves #392.