### PR TITLE
Improve type formatting logic in :cast function

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,7 +702,7 @@ have a lot of function calls needed in code:
     (sql/format {:pretty true}))
 => ["
 INSERT INTO sample
-(location) VALUES (ST_SETSRID(ST_MAKEPOINT(?, ?), CAST(? AS integer)))
+(location) VALUES (ST_SETSRID(ST_MAKEPOINT(?, ?), CAST(? AS INTEGER)))
 "
 0.291 32.621 4325]
 ```

--- a/doc/special-syntax.md
+++ b/doc/special-syntax.md
@@ -79,7 +79,7 @@ that produces a SQL type:
 
 ```clojure
 (sql/format-expr [:cast :a :int])
-;;=> ["CAST(a AS int)"]
+;;=> ["CAST(a AS INT)"]
 ```
 
 ## composite

--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -1426,7 +1426,9 @@
     :cast
     (fn [_ [x type]]
       (let [[sql & params]   (format-expr x)
-            [sql' & params'] (format-expr type)]
+            [sql' & params'] (if (ident? type)
+                               [(sql-kw type)]
+                               (format-expr type))]
         (-> [(str "CAST(" sql " AS " sql' ")")]
             (into params)
             (into params'))))

--- a/test/honey/sql/helpers_test.cljc
+++ b/test/honey/sql/helpers_test.cljc
@@ -249,10 +249,19 @@
                (sql/format))))))
 
 (deftest test-cast
-  (is (= ["SELECT foo, CAST(bar AS integer)"]
+  (is (= ["SELECT foo, CAST(bar AS INTEGER)"]
          (sql/format {:select [:foo [[:cast :bar :integer]]]})))
-  (is (= ["SELECT foo, CAST(bar AS integer)"]
-         (sql/format {:select [:foo [[:cast :bar 'integer]]]}))))
+  (is (= ["SELECT foo, CAST(bar AS INTEGER)"]
+         (sql/format {:select [:foo [[:cast :bar 'integer]]]})))
+  (is (= ["SELECT foo, CAST(bar AS DOUBLE PRECISION)"] ;; Postgres example
+         (sql/format {:select [:foo [[:cast :bar :double-precision]]]})))
+  (is (= ["SELECT \"foo\", CAST(\"bar\" AS INTEGER)"]
+         (sql/format {:select [:foo [[:cast :bar :integer]]]} {:quoted true})))
+  (is (= ["SELECT `foo`, CAST(`bar` AS INTEGER)"]
+         (sql/format {:select [:foo [[:cast :bar :integer]]]} {:dialect :mysql})))
+  (is (= ["SELECT `foo`, CAST(`bar` AS CHAR(10))"]
+         (sql/format {:select [:foo [[:cast :bar [:char 10]]]]} {:dialect :mysql
+                                                                 :inline true}))))
 
 (deftest test-value
   (is (= ["INSERT INTO foo (bar) VALUES (?)" {:baz "my-val"}]


### PR DESCRIPTION
In the `:cast` function (special syntax), if the `type` is keyword or symbol, it can be quoted according to the format option.

```clojure
;; Example

(sql/format {:select [:foo [[:cast :bar :integer]]]} {:quoted true})
=> ["SELECT \"foo\", CAST(\"bar\" AS \"integer\")"]

(sql/format {:select [:foo [[:cast :bar :integer]]]} {:dialect :mysql})
=> ["SELECT `foo`, CAST(`bar` AS `integer`)"]
```

It is not valid that `type` to be quoted in the CAST( expr AS `type` ) syntax. Therefore, I modified the formatter of `:cast` to use `sql-kw` when the `type` is keyword or symbol. And I also added related tests.