### PR TITLE
[POC] Support numbered parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -871,11 +871,11 @@ Or perhaps your database supports syntax like `a BETWIXT b AND c`, in which case
 ;; sequence of the arguments provided to it (so you can write any arity ops):
 (sql/register-fn! :betwixt
                   (fn [op [a b c]]
-                    (let [[sql-a & params-a] (sql/format-expr a)
-                          [sql-b & params-b] (sql/format-expr b)
-                          [sql-c & params-c] (sql/format-expr c)]
-                      (-> [(str sql-a " " (sql/sql-kw op) " "
-                                sql-b " AND " sql-c)]
+                    (let [[sql-a & params-a] (sql/-format-expr a)
+                          [sql-b & params-b] (sql/-format-expr b)
+                          [sql-c & params-c] (sql/-format-expr c)]
+                      (-> [(vector sql-a " " (sql/sql-kw op) " "
+                                   sql-b " AND " sql-c)]
                           (c/into params-a)
                           (c/into params-b)
                           (c/into params-c)))))
@@ -894,9 +894,9 @@ You can also register SQL clauses, specifying the keyword, the formatting functi
                       (fn [clause x]
                         (let [[sql & params]
                               (if (ident? x)
-                                (sql/format-expr x)
+                                (sql/-format-expr x)
                                 (sql/format-dsl x))]
-                          (c/into [(str (sql/sql-kw clause) " " sql)] params)))
+                          (c/into [(vector (sql/sql-kw clause) " " sql)] params)))
                       :from) ; SELECT ... FOOBAR ... FROM ...
 ;; example usage:
 (sql/format {:select [:a :b] :foobar :baz})

--- a/doc/extending-honeysql.md
+++ b/doc/extending-honeysql.md
@@ -164,8 +164,8 @@ of it and would call `sql/format-expr` on each argument:
 
 ```clojure
 (defn- foo-formatter [f [x]]
-  (let [[sql & params] (sql/format-expr x)]
-    (into [(str (sql/sql-kw f) "(" sql ")")] params)))
+  (let [[sql & params] (sql/-format-expr x)]
+    (into [(vector (sql/sql-kw f) "(" sql ")")] params)))
 
 (sql/register-fn! :foo foo-formatter)
 

--- a/test/honey/sql_test.cljc
+++ b/test/honey/sql_test.cljc
@@ -70,7 +70,8 @@
 
 (deftest where-test
   (is (= ["WHERE id = ?" 1]
-         (#'sut/format-on-expr :where [:= :id 1]))))
+         (-> (#'sut/format-on-expr :where [:= :id 1])
+             (#'sut/internal->sql)))))
 
 (deftest general-tests
   (is (= ["SELECT * FROM \"table\" WHERE \"id\" = ?" 1]


### PR DESCRIPTION
POC #405

#### Approach

Change the internal presentation of sql from string to nested vector of sql fragments.
Convert back to SQL string only on public consumer API `sql/format`, `sql/format-expr`.

* Replace all `(str ...)` and `(str/join ...)` to `vector`/`interpose`.
* Replace hardcoded `"?"` to marker `:parameter-marker`
* Convert parameter marker to '?' or '$1' when convert sql fragments to string.

##### Good

* No impact on user that only use `helper` or `format`
* Minimum changes in current code base

##### Bad

* Breaking changes in extension API
* Internal Presentation become a forest of vectors

#### Checklist

- [x] workable implementation for discussion
- [x] Pass all tests
- [ ] Update documentation

#### Thoughts

* Align all internal/extend fn to output `[sqls params]`, all external fn to output `[sql param1 param2 ...]` may help to make code even more concise.
* Separate user api/extension api. e.g. `format-expr` separate into `format-expr` and `-format-expr`.
* Standardize the intermediate presentation format.
 