### PR TITLE
Implement a basic SQLite dialect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Fix [#434](https://github.com/seancorfield/honeysql/issues/434) by special-casing `:'ARRAY`.
   * Fix [#433](https://github.com/seancorfield/honeysql/issues/433) by supporting additional `WITH` syntax, via PR [#432](https://github.com/seancorfield/honeysql/issues/432), [@MawiraIke](https://github.com/MawiraIke). _[Technically, this was in 2.4.947, but I kept the issue open while I wordsmithed the documentation]_
   * Address [#405](https://github.com/seancorfield/honeysql/issues/405) by adding `:numbered` option, which can also be set globally using `set-options!`.
+  * Support `REPLACE INTO` syntax in SQLite by adding a `:sqlite` dialect.
 
 * 2.4.947 -- 2022-11-05
   * Fix [#439](https://github.com/seancorfield/honeysql/issues/439) by rewriting how DDL options are processed; also fixes [#386](https://github.com/seancorfield/honeysql/issues/386) and [#437](https://github.com/seancorfield/honeysql/issues/437); **Whilst this is intended to be purely a bug fix, it has the potential to be a breaking change -- hence the version jump to 2.4!**

--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -112,7 +112,16 @@
                                   (add-clause-before :set :where)
                                   ;; ...but not in-flight clauses:
                                   (add-clause-before :replace-into :insert-into)))}
-               :oracle    {:quote #(strop \" % \") :as false}})))
+               :oracle    {:quote #(strop \" % \") :as false}
+               :sqlite    {:quote #(strop \" % \")
+                           :clause-order-fn
+                           #(do
+                              ;; side-effect: updates global clauses...
+                              (register-clause! :replace-into :insert-into :insert-into)
+                              (-> %
+                                  (add-clause-before :set :where)
+                                  ;; ...but not in-flight clauses:
+                                  (add-clause-before :replace-into :insert-into)))}})))
 
 ; should become defonce
 (def ^:private default-dialect (atom (:ansi @dialects)))
@@ -1707,7 +1716,7 @@
 (defn set-dialect!
   "Set the default dialect for formatting.
 
-  Can be: `:ansi` (the default), `:mysql`, `:oracle`, or `:sqlserver`.
+  Can be: `:ansi` (the default), `:mysql`, `:oracle`, `:sqlserver` or `:sqlite`.
 
   Can optionally accept `:quoted true` (or `:quoted false`) to set the
   default global quoting strategy. Without `:quoted`, the default global


### PR DESCRIPTION
This dialect allows for supporting the same `REPLACE INTO` syntax supported by MySQL, without changing the quote format or other behaviors.  This allows the dialect to also be extended in the future with SQLite-specific syntax.

Alternatively, the `REPLACE INTO` syntax could be made to be used without any dialects.