### PR TITLE
Allow single kw in :order-by and other clauses

### DIFF
--- a/src/honey/sql/helpers.cljc
+++ b/src/honey/sql/helpers.cljc
@@ -51,7 +51,11 @@
 ;; implementation helpers:
 
 (defn- default-merge [current args]
-  (c/into (vec current) args))
+  (let [current (cond
+                  (nil? current) []
+                  (sequential? current) (vec current)
+                  :else [current])]
+    (c/into current args)))
 
 (defn- sym->kw
   "Given a symbol, produce a keyword, retaining the namespace

--- a/test/honey/sql/helpers_test.cljc
+++ b/test/honey/sql/helpers_test.cljc
@@ -144,14 +144,14 @@
 (deftest select-top-tests
   (testing "Basic TOP syntax"
     (is (= ["SELECT TOP(?) foo FROM bar ORDER BY quux ASC" 10]
-           (sql/format {:select-top [10 :foo] :from :bar :order-by [:quux]})))
+           (sql/format {:select-top [10 :foo] :from :bar :order-by :quux})))
     (is (= ["SELECT TOP(?) foo FROM bar ORDER BY quux ASC" 10]
            (sql/format (-> (select-top 10 :foo)
                            (from :bar)
                            (order-by :quux))))))
   (testing "Expanded TOP syntax"
     (is (= ["SELECT TOP(?) PERCENT WITH TIES foo, baz FROM bar ORDER BY quux ASC" 10]
-           (sql/format {:select-top [[10 :percent :with-ties] :foo :baz] :from :bar :order-by [:quux]})))
+           (sql/format {:select-top [[10 :percent :with-ties] :foo :baz] :from :bar :order-by :quux})))
     (is (= ["SELECT TOP(?) PERCENT WITH TIES foo, baz FROM bar ORDER BY quux ASC" 10]
            (sql/format (-> (select-top [10 :percent :with-ties] :foo :baz)
                            (from :bar)
@@ -865,7 +865,7 @@
                                  [[:filter ; two pairs -- alias is on last pair
                                    [:avg :x [:order-by :y [:a :desc]]] {:where [:< :i 10]}
                                    [:sum :q] {:where [:= :x nil]}] :b]
-                                 [[:within-group [:foo :y] {:order-by [:x]}]]]})
+                                 [[:within-group [:foo :y] {:order-by :x}]]]})
            [(str "SELECT COUNT(*) FILTER (WHERE i > ?) AS a,"
                  " AVG(x, y ORDER BY a DESC) FILTER (WHERE i < ?),"
                  " SUM(q) FILTER (WHERE x IS NULL) AS b,"

--- a/test/honey/sql/postgres_test.cljc
+++ b/test/honey/sql/postgres_test.cljc
@@ -255,6 +255,12 @@
              (sql/format)))))
 
 (deftest over-test
+  (testing "simple window statement"
+    (is (= ["SELECT AVG(salary) OVER w FROM employee WINDOW w AS (PARTITION BY department ORDER BY salary ASC)"]
+           (sql/format {:select [[[:over [[:avg :salary] :w]]]]
+                        :from   :employee
+                        :window [:w {:partition-by :department
+                                     :order-by     :salary}]}))))
   (testing "window function over on select statemt"
     (is (= ["SELECT id, AVG(salary) OVER (PARTITION BY department ORDER BY designation ASC) AS Average, MAX(salary) OVER w AS MaxSalary FROM employee WINDOW w AS (PARTITION BY department)"]
            ;; honeysql treats over as a function:

--- a/test/honey/sql_test.cljc
+++ b/test/honey/sql_test.cljc
@@ -83,10 +83,14 @@
          (sut/format {:select [:*] :from [:table] :where (sut/map= {:id 1})} {:quoted true})))
   (is (= ["SELECT \"t\".* FROM \"table\" AS \"t\" WHERE \"id\" = ?" 1]
          (sut/format {:select [:t.*] :from [[:table :t]] :where [:= :id 1]} {:quoted true})))
+  (is (= ["SELECT * FROM \"table\" GROUP BY \"foo\""]
+         (sut/format {:select [:*] :from [:table] :group-by :foo} {:quoted true})))
   (is (= ["SELECT * FROM \"table\" GROUP BY \"foo\", \"bar\""]
          (sut/format {:select [:*] :from [:table] :group-by [:foo :bar]} {:quoted true})))
   (is (= ["SELECT * FROM \"table\" GROUP BY DATE(\"bar\")"]
          (sut/format {:select [:*] :from [:table] :group-by [[:date :bar]]} {:quoted true})))
+  (is (= ["SELECT * FROM \"table\" ORDER BY \"foo\" ASC"]
+         (sut/format {:select [:*] :from [:table] :order-by :foo} {:quoted true})))
   (is (= ["SELECT * FROM \"table\" ORDER BY \"foo\" DESC, \"bar\" ASC"]
          (sut/format {:select [:*] :from [:table] :order-by [[:foo :desc] :bar]} {:quoted true})))
   (is (= ["SELECT * FROM \"table\" ORDER BY DATE(\"expiry\") DESC, \"bar\" ASC"]


### PR DESCRIPTION
Fixes #467 

Also fixes not being able to use helpers to merge into stuff like `{:select :id}` - e.g. `(hh/select {:select :id} :x)` would throw.

I would also update README so it mentions the "plain" syntax earlier and uses it wherever possible.