### PR TITLE
Proposed opt `quoted-when`

### DIFF
--- a/doc/options.md
+++ b/doc/options.md
@@ -22,6 +22,7 @@ All options may be omitted. The default behavior of each option is described in 
 * `:numbered` -- a Boolean indicating whether to generate numbered placeholders in the generated SQL (`$1`, `$2`, etc) or positional placeholders (`?`); the default is `false` (positional placeholders); this option was added in 2.4.962,
 * `:params` -- a hash map providing values for named parameters, identified by names (keywords or symbols) that start with `?` in the DSL; the default is that any such named parameters will have `nil` values,
 * `:quoted` -- a Boolean indicating whether or not to quote (strop) SQL entity names (table and column names); the default is `nil` -- alphanumeric SQL entity names are not quoted but (as of 2.3.928) "unusual" SQL entity names are quoted; a `false` value turns off all quoting,
+* `:quoted-when` -- a function overriding the default behavior of when to quote entities when `:quoted false` (default). Function should take single argument - the entity/part being quoted - and return a boolean indicator whether to quote it or not.
 * `:quoted-snake` -- a Boolean indicating whether or not quoted and string SQL entity names should have `-` replaced by `_`; the default is `false` -- quoted and string SQL entity names are left exactly as-is,
 * `:values-default-columns` -- a sequence of column names that should have `DEFAULT` values instead of `NULL` values if used in a `VALUES` clause with no associated matching value in the hash maps passed in; the default behavior is for such missing columns to be given `NULL` values.
 

--- a/test/honey/sql/helpers_test.cljc
+++ b/test/honey/sql/helpers_test.cljc
@@ -263,6 +263,10 @@
          (sql/format {:select [:foo [[:cast :bar [:char 10]]]]} {:dialect :mysql
                                                                  :inline true}))))
 
+(deftest test-quoting
+  (is (= ["SELECT foo, \"bar\""]
+         (sql/format {:select [:foo :bar]} {:quoted-when #(some #{%} ["bar"])})))) ;; Example showing only quoting reserved words
+
 (deftest test-value
   (is (= ["INSERT INTO foo (bar) VALUES (?)" {:baz "my-val"}]
          (->


### PR DESCRIPTION
Hello @seancorfield 

Proposing a new option, `quoted-when`, to allow overriding the default (opinionated) quoting when quoting has been disabled.

This can be useful, for example, if a user wants to selectively quote fields like only quoting reserved words.

Welcome to any feedback and appreciate all the great work on honeysql.

Best,