### PR TITLE
Update pg-ops/- docstring wrt array input

### DIFF
--- a/src/honey/sql/pg_ops.cljc
+++ b/src/honey/sql/pg_ops.cljc
@@ -49,6 +49,7 @@
 (def -
   "The - operator: 
    - text value: deletes a key (and its value) from a JSON object, or matching string value(s) from a JSON array
+   - text[] array value: as above, but for all the provided keys
    - int value: deletes the array element with specified index (negative integers count from the end)"
   :-)
 (def hash-  "The #- operator - deletes the field or array element at the specified path, where path elements can be either field keys or array indexes."  :#-)


### PR DESCRIPTION
The `-` operator also works for arrays:

```sql
select '{"a":1,"b":2,"c":3}' - array['a','b'];
-- => {c:3}
select '["a","b","c"]'::jsonb - array['a','b']
-- => ["c"]
```