### PR TITLE
additional docs for cte

### DIFF
--- a/doc/clause-reference.md
+++ b/doc/clause-reference.md
@@ -476,6 +476,16 @@ user=> (sql/format {:with [[[:stuff {:columns [:id :name]}]
 
 > Note: you must use the vector-of-vectors format for `:values` here -- if you try to use the vector-of-maps format, `VALUES` will be preceded by the column names (keys from the maps) and the resultant SQL will be invalid.
 
+You can specify `MATERIALIZED`, `NOT MATERIALIZED` for the CTE:
+
+```clojure
+user=> (sql/format {:with [[:stuff {:select :*
+                                    :from :table} :not-materialized]]
+                    :select :*
+                    :from :stuff})
+["WITH stuff AS NOT MATERIALIZED (SELECT * FROM table) SELECT * FROM stuff"]
+```
+
 `:with-recursive` follows the same rules as `:with` and produces `WITH RECURSIVE` instead of just `WITH`.
 
 ## intersect, union, union-all, except, except-all


### PR DESCRIPTION
a small example was added to illustrate how to specify a Common Table Expression (CTE) as materialized or not materialized.