### PR TITLE
Hodgepodge of optimizations

### DIFF
--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -161,8 +161,8 @@
 (def ^:no-doc ^:dynamic *escape-?* true)
 
 ;; suspicious entity names:
-(def ^:private suspicious #";")
-(defn- suspicious? [s] (boolean (re-find suspicious s)))
+(def ^:private suspicious ";")
+(defn- suspicious? [s] (str/includes? s suspicious))
 (defn- suspicious-entity-check [entity]
     (when-not *allow-suspicious-entities*
       (when (suspicious? entity)

--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -110,16 +110,16 @@
    (reduce-kv (fn [m k v]
                 (assoc m k (assoc v :dialect k)))
               {}
-              {:ansi      {:quote #(strop \" % \")}
-               :sqlserver {:quote #(strop \[ % \])}
-               :mysql     {:quote #(strop \` % \`)
+              {:ansi      {:quote #(strop "\"" % "\"")}
+               :sqlserver {:quote #(strop "[" % "]")}
+               :mysql     {:quote #(strop "`" % "`")
                            :clause-order-fn
                            #(add-clause-before % :set :where)}
-               :nrql      {:quote    #(strop \` % \`)
+               :nrql      {:quote    #(strop "`" % "`")
                            :col-fn   #(if (keyword? %) (subs (str %) 1) (str %))
                            :parts-fn vector}
-               :oracle    {:quote #(strop \" % \") :as false}
-               :xtdb      {:quote    #(strop \" % \")
+               :oracle    {:quote    #(strop "\"" % "\"") :as false}
+               :xtdb      {:quote    #(strop "\"" % "\"")
                            :col-fn   #(if (keyword? %) (subs (str %) 1) (str %))
                            :parts-fn #(str/split % #"\.")}})))
 

--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -272,7 +272,7 @@
    * the whole entity is numeric (with optional underscores), or
    * the first character is alphabetic (or underscore) and the rest is
      alphanumeric (or underscore)."
-  #"^([0-9_]+|[A-Za-z_][A-Za-z0-9_]*)$")
+  #"^(?:[0-9_]+|[A-Za-z_][A-Za-z0-9_]*)$")
 
 (defn format-entity
   "Given a simple SQL entity (a keyword or symbol -- or string),

--- a/src/honey/sql/util.cljc
+++ b/src/honey/sql/util.cljc
@@ -7,7 +7,6 @@
   "More efficient implementation of `clojure.core/str` because it has more
   non-variadic arities. Optimization is Clojure-only, on other platforms it
   reverts back to `clojure.core/str`."
-  {:tag String}
   (^String [] "")
   (^String [^Object a]
    #?(:clj (if (nil? a) "" (.toString a))


### PR DESCRIPTION
Following #545, here's a bunch of further improvements to HoneySQL efficiency. Commits are meaningful, I've included the explanations in the commit descriptions.

Benchmark I've used:

```clj
(format {:select [[[:min :recent_views.user_id] :user_id]
                  :model
                  :model_id
                  [[:max [:coalesce :d.view_count :t.view_count]] :cnt]
                  [:%max.timestamp :max_ts]]
         :group-by  [:model :model_id]
         :where     [:and
                     [:= :context "view"]
                     [:in :model #{"dashboard" "table"}]]
         :order-by  [[:max_ts :desc] [:model :desc]]
         :limit     10
         :left-join [[:report_dashboard :d]
                     [:and
                      [:= :model "dashboard"]
                      [:= :d.id :model_id]]
                     [:metabase_table :t]
                     [:and
                      [:= :model "table"]
                      [:= :t.id :model_id]]]}
        {:dialect :ansi})
```

```
Before:
Time per call: 50.31 us   Alloc per call: 121,104b
Time per call: 45.95 us   Alloc per call: 121,171b
Time per call: 43.92 us   Alloc per call: 121,104b

After:
Time per call: 35.65 us   Alloc per call: 82,392b
Time per call: 35.39 us   Alloc per call: 82,392b
Time per call: 35.25 us   Alloc per call: 82,392b
```