### PR TITLE
More optimizations

### DIFF
--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -1753,7 +1753,10 @@
   (if (keyword? k)
     (if-let [n (namespace k)]
       (symbol n (name k))
-      (symbol (name k)))
+      ;; In CLJ runtime, reuse symbol that's already present in the keyword.
+      #?(:bb (symbol (name k))
+         :clj (.sym ^clojure.lang.Keyword k)
+         :default (symbol (name k))))
     k))
 
 (defn format-dsl

--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -31,7 +31,7 @@
   (:require [clojure.string :as str]
             #?(:clj [clojure.template])
             [honey.sql.protocols :as p]
-            [honey.sql.util :refer [str join]]))
+            [honey.sql.util :refer [str join split-by-separator]]))
 
 ;; default formatting for known clauses
 
@@ -316,7 +316,7 @@
                             [n %]
                             (if aliased
                               [%]
-                              (str/split % #"\."))))
+                              (split-by-separator % "."))))
          parts       (parts-fn col-e)
          entity      (join "." (map #(cond-> % (not= "*" %) (quote-fn))) parts)]
      (suspicious-entity-check entity)
@@ -457,7 +457,7 @@
                 :default (subs (str x) 1))
              (str x))]
      (cond (str/starts-with? c "%")
-           (let [[f & args] (str/split (subs c 1) #"\.")]
+           (let [[f & args] (split-by-separator (subs c 1) ".")]
              [(str (format-fn-name f) "("
                    (join ", " (map #(format-entity (keyword %) opts)) args)
                    ")")])

--- a/src/honey/sql/util.cljc
+++ b/src/honey/sql/util.cljc
@@ -88,3 +88,19 @@
         ;; Fastpath - zero separators in s
         [s]
         (conj res (subs s start))))))
+
+(defn into*
+  "An extension of `clojure.core/into` that accepts multiple \"from\" arguments.
+  Doesn't support `xform`."
+  ([to from1] (into* to from1 nil nil nil))
+  ([to from1 from2] (into* to from1 from2 nil nil))
+  ([to from1 from2 from3] (into* to from1 from2 from3 nil))
+  ([to from1 from2 from3 from4]
+   (if (or from1 from2 from3 from4)
+     (as-> (transient to) to'
+       (reduce conj! to' from1)
+       (reduce conj! to' from2)
+       (reduce conj! to' from3)
+       (reduce conj! to' from4)
+       (persistent! to'))
+     to)))

--- a/src/honey/sql/util.cljc
+++ b/src/honey/sql/util.cljc
@@ -75,3 +75,16 @@
 
       :default
       (clojure.string/join separator (transduce xform conj [] coll)))))
+
+(defn split-by-separator
+  "More efficient implementation of `clojure.string/split` for cases when a
+  literal string (not regex) is used as a separator, and for cases where the
+  separator is not present in the haystack at all."
+  [s sep]
+  (loop [start 0, res []]
+    (if-let [sep-idx (clojure.string/index-of s sep start)]
+      (recur (inc sep-idx) (conj res (subs s start sep-idx)))
+      (if (= start 0)
+        ;; Fastpath - zero separators in s
+        [s]
+        (conj res (subs s start))))))

--- a/test/honey/util_test.cljc
+++ b/test/honey/util_test.cljc
@@ -43,3 +43,11 @@
   (is (= "1, 2, 3, 4"
          (sut/join ", " (remove nil?) [1 nil 2 nil 3 nil nil nil 4])))
   (is (= "" (sut/join ", " (remove nil?) [nil nil nil nil]))))
+
+(deftest split-by-separator-test
+  (is (= [""] (sut/split-by-separator "" ".")))
+  (is (= ["" ""] (sut/split-by-separator "." ".")))
+  (is (= ["hello"] (sut/split-by-separator "hello" ".")))
+  (is (= ["h" "e" "l" "l" "o"] (sut/split-by-separator "h.e.l.l.o" ".")))
+  (is (= ["" "h" "e" "" "" "l" "" "l" "o" ""]
+         (sut/split-by-separator ".h.e...l..l.o." "."))))

--- a/test/honey/util_test.cljc
+++ b/test/honey/util_test.cljc
@@ -51,3 +51,12 @@
   (is (= ["h" "e" "l" "l" "o"] (sut/split-by-separator "h.e.l.l.o" ".")))
   (is (= ["" "h" "e" "" "" "l" "" "l" "o" ""]
          (sut/split-by-separator ".h.e...l..l.o." "."))))
+
+(deftest into*-test
+  (is (= [1] (sut/into* [1] nil)))
+  (is (= [1] (sut/into* [1] [])))
+  (is (= [1] (sut/into* [1] nil [] nil [])))
+  (is (= [1 2 3] (sut/into* [1] [2 3])))
+  (is (= [1 2 3 4 5 6] (sut/into* [1] [2 3] [4 5 6])))
+  (is (= [1 2 3 4 5 6 7] (sut/into* [1] [2 3] [4 5 6] [7])))
+  (is (= [1 2 3 4 5 6 7 8 9] (sut/into* [1] [2 3] [4 5 6] [7] [8 9]))))


### PR DESCRIPTION
Here are some more easy optimizations discovered while benchmarking Metabase's usage of HoneySQL.

1. `clojure.string/split` uses the regex machinery which is generally more wasteful than searching for a substring manually. HoneySQL so far only looks for `.` when splitting names. Besides, plenty of names don't have `.` in them and they still pay the regex tax. The new splitter function allocates nothing in such case.
2. Clojure's Keyword object already contains a corresponding Symbol, so we can return it in `kw->sym` (if there is no namespace). We could actually just call `(symbol kw)` for the same effect, but I think this behavior was introduced in Clojure 1.10, and HoneySQL claims to support 1.9.
3. I again tried to address the into's transient-persistent roundtrip. This time, I'm not making any speculative and potentially damaging changes. There are a lot of places in the code where `into` is used multiple times in succession, hence `into*` (name is up to be changed) both makes the code cleaner and prevents unnecessary transient roundtrips inbetween.