### PR TITLE
More small optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changes
 
 * 2.6.next in progress
-  * More performance optimizations via PR [#560](https://github.com/seancorfield/honeysql/pull/560) [@alexander-yakushev](https://github.com/alexander-yakushev).
+  * More performance optimizations via PRs [#560](https://github.com/seancorfield/honeysql/pull/560) and [#562](https://github.com/seancorfield/honeysql/pull/562) [@alexander-yakushev](https://github.com/alexander-yakushev).
   * Fix two broken links to the [HoneySQL web app](https://john.shaffe.rs/honeysql/) via PR [#559](https://github.com/seancorfield/honeysql/pull/559) [@whatacold](https://github.com/whatacold).
   * Make SQL Server dialect auto-lift Boolean values to parameters since SQL Server has no `TRUE` / `FALSE` literals.
 

--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -227,7 +227,8 @@
 
   Hyphens at the start or end of a string should not be touched."
   [s]
-  (str/replace s #"(\w)-(?=\w)" "$1 "))
+  (cond-> s
+    (str/includes? s "-") (str/replace #"(\w)-(?=\w)" "$1 ")))
 
 (defn- namespace-_
   "Return the namespace portion of a symbol, with dashes converted."


### PR DESCRIPTION
The first one saves a bit on that regexpy `str/replace` if the keyword already doesn't contain any hyphens. Alternatively, it could be rewritten into some explicit loop that looks for hyphens and then checks if they aren't on the edges of the string, but I don't think the complication is worth it. Checking for present hyphen is easy and quick, and given that most keywords don't have hyphens, this already saves most of what it is there to be saved.

The second one is some streamlining of code inside `format-values`. The refactored version tries to do most of work inside the `reduce` loop, without pre-processing stuff with `map` first.