### PR TITLE
Explain double colon :: syntax for cast

### DIFF
--- a/doc/special-syntax.md
+++ b/doc/special-syntax.md
@@ -231,6 +231,8 @@ or:
 
 > Note: In HoneySQL 2.4.947 and earlier, the type name was incorrectly affected by the quoting feature, and a hyphen in a type name was incorrectly changed to underscore. This was corrected in 2.4.962.
 
+You can also use this instead of the double colon `::` syntax.  E.g. instead of `a::citext` write `CAST(a AS CITEXT)` as `[:cast :a :citext]`.
+
 ## composite
 
 Accepts any number of expressions and produces a composite


### PR DESCRIPTION
Add a hint to invoke `cast` instead of using the double colon `::` syntax.

I could not find an explanation how to render the `col::type` syntax and it took an excursion to the history of the Slack `#honeysql` channel to figure out what to do.  This documents my findings.

References: https://clojurians.slack.com/archives/C66EM8D5H/p1702579675520789?thread_ts=1702577803.253389&cid=C66EM8D5H