### PR TITLE
Add window frame support via :frame clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changes
 
 * 2.7.next in progress
+  * Add support for window frames via the `:frame` clause (and `frame` helper) inside `:over` expressions and `:window` definitions, e.g. `{:frame [:rows :between :unbounded-preceding :current-row]}` produces `ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`. Supports `:rows`/`:range`/`:groups` modes, single or `:between` bounds (`:unbounded-preceding`, `:current-row`, `:unbounded-following`, or `[n :preceding]`/`[n :following]` offset pairs), and frame exclusions.
   * Note that PostgreSQL also supports `CASE` via PR [#598](https://github.com/seancorfield/honeysql/pull/598) from [@holyjak](https://github.com/holyjak).
   * Upgrade from EPL-1.0 to EPL-2.0 for broader compatibility. Explicitly allow for relicensing of HoneySQL code under Apache-2.0.
   * Update dev/test deps.

--- a/doc/clause-reference.md
+++ b/doc/clause-reference.md
@@ -20,7 +20,8 @@ The examples herein assume:
 (refer-clojure :exclude '[partition-by])
 (require '[honey.sql :as sql]
          '[honey.sql.helpers :as h :refer [select from join-by left-join join
-                                           where order-by over partition-by window]])
+                                           where order-by over partition-by window
+                                           frame]])
 ```
 
 Every DDL and SQL clause has a corresponding helper function
@@ -1242,6 +1243,69 @@ user=> (sql/format (-> (select :id
                                      [[:max :salary] nil :MaxSalary]))
                        (from :employee)))
 ["SELECT id, AVG(salary) OVER () AS Average, MAX(salary) OVER () AS MaxSalary FROM employee"]
+```
+
+## frame
+
+`:frame` adds a window frame (the `ROWS` / `RANGE` / `GROUPS` portion of a
+window specification) inside an `:over` expression or a named `:window`
+definition. It is given as a vector, in SQL token order:
+
+* a frame mode -- `:rows`, `:range` or `:groups`,
+* either a single frame start bound, or `:between` followed by a start
+  bound and an end bound,
+* an optional frame exclusion -- `:exclude-current-row`, `:exclude-group`,
+  `:exclude-ties` or `:exclude-no-others`.
+
+A bound is either one of the keywords `:unbounded-preceding`,
+`:current-row` or `:unbounded-following`, or a pair of an offset and a
+direction, `[n :preceding]` or `[n :following]`. The offset is formatted as
+a regular SQL expression, so it may be a literal (parameterized, or inlined
+with the `:inline` option), a named parameter, or any expression.
+
+`:frame` always appears after `:partition-by` and `:order-by` within the
+window specification.
+
+```clojure
+user=> (sql/format {:select [:id
+                             [[:over
+                               [[:sum :salary]
+                                {:partition-by [:department]
+                                 :order-by [:salary]
+                                 :frame [:rows :between :unbounded-preceding :current-row]}
+                                :running-total]]]]
+                    :from [:employee]})
+["SELECT id, SUM(salary) OVER (PARTITION BY department ORDER BY salary ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running_total FROM employee"]
+;; easier to write with helpers (and easier to read!):
+user=> (sql/format (-> (select :id
+                               (over [[:sum :salary]
+                                      (-> (partition-by :department)
+                                          (order-by :salary)
+                                          (frame :rows :between :unbounded-preceding :current-row))
+                                      :running-total]))
+                       (from :employee)))
+["SELECT id, SUM(salary) OVER (PARTITION BY department ORDER BY salary ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running_total FROM employee"]
+;; offset bounds are formatted as expressions (here, parameters):
+user=> (sql/format {:select [[[:over
+                               [[:avg :salary]
+                                {:order-by [:salary]
+                                 :frame [:range :between [100 :preceding] [100 :following]]}
+                                :moving-avg]]]]
+                    :from [:employee]})
+["SELECT AVG(salary) OVER (ORDER BY salary ASC RANGE BETWEEN ? PRECEDING AND ? FOLLOWING) AS moving_avg FROM employee" 100 100]
+;; a single start bound, with a frame exclusion:
+user=> (sql/format {:select [[[:over
+                               [[:sum :salary]
+                                {:order-by [:salary]
+                                 :frame [:groups :current-row :exclude-ties]}
+                                :grp]]]]
+                    :from [:employee]})
+["SELECT SUM(salary) OVER (ORDER BY salary ASC GROUPS CURRENT ROW EXCLUDE TIES) AS grp FROM employee"]
+;; a frame may also be given in a named WINDOW definition:
+user=> (sql/format {:select [:id [[:over [[:sum :salary] {:partition-by [:department]} :dept-total]]]]
+                    :from [:employee]
+                    :window [:w {:order-by [:salary] :frame [:rows :unbounded-preceding]}]})
+["SELECT id, SUM(salary) OVER (PARTITION BY department) AS dept_total FROM employee WINDOW w AS (ORDER BY salary ASC ROWS UNBOUNDED PRECEDING)"]
 ```
 
 ## distinct, expr

--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -72,7 +72,8 @@
    ;; NRQL extension:
    :facet
    :window :partition-by
-   :order-by :limit :offset :fetch :for :lock :values :records
+   :order-by :frame
+   :limit :offset :fetch :for :lock :values :records
    :on-conflict :on-constraint :do-nothing :do-update-set :on-duplicate-key-update
    :returning
    :with-data
@@ -1161,6 +1162,63 @@
                                   dirs)))] params)
       [])))
 
+(def ^:private frame-modes
+  "The three SQL window frame modes."
+  #{:rows :range :groups})
+
+(def ^:private frame-exclusions
+  "The four SQL window frame exclusion options."
+  #{:exclude-current-row :exclude-group :exclude-ties :exclude-no-others})
+
+(defn- format-frame-bound
+  "Format a single window frame bound. A bound is either a keyword such as
+  :unbounded-preceding, :current-row or :unbounded-following (rendered
+  literally via sql-kw) or a pair [offset :preceding] / [offset :following]
+  where the offset is formatted as a SQL expression so it supports
+  parameters, :inline and arbitrary expressions, mirroring order-by's
+  [expr dir] pairs."
+  [b]
+  (if (sequential? b)
+    (let [[offset dir]   b
+          [sql & params] (format-expr offset)]
+      (into [(str sql " " (sql-kw dir))] params))
+    [(sql-kw b)]))
+
+(defn- format-frame [_ xs]
+  (let [xs             (ensure-sequential xs)
+        [mode & more]  xs
+        mode           (sym->kw mode)
+        between?       (= :between (sym->kw (first more)))
+        more           (if between? (rest more) more)
+        n              (if between? 2 1)
+        bounds         (take n more)
+        [excl & extra] (drop n more)
+        excl           (when excl (sym->kw excl))]
+    (when-not (contains? frame-modes mode)
+      (throw (ex-info (str "window frame mode must be one of :rows, :range or :groups, got: " mode)
+                      {:frame xs})))
+    (when-not (= n (count bounds))
+      (throw (ex-info (str "window frame " (sql-kw mode)
+                           (when between? " BETWEEN")
+                           " expects " n " bound" (when (< 1 n) "s"))
+                      {:frame xs})))
+    (when (and excl (not (contains? frame-exclusions excl)))
+      (throw (ex-info (str "invalid window frame exclusion: " excl)
+                      {:frame xs})))
+    (when (seq extra)
+      (throw (ex-info "malformed window frame: unexpected trailing elements"
+                      {:frame xs :trailing extra})))
+    (let [results    (map format-frame-bound bounds)
+          bound-sqls (map first results)
+          params     (mapcat rest results)
+          body       (str (sql-kw mode) " "
+                          (if between?
+                            (str "BETWEEN " (first bound-sqls)
+                                 " AND " (second bound-sqls))
+                            (first bound-sqls))
+                          (when excl (str " " (sql-kw excl))))]
+      (into [body] params))))
+
 (defn- format-lock-strength [k xs]
   (let [[strength tables nowait] (ensure-sequential xs)]
     [(str (sql-kw k) " " (sql-kw strength)
@@ -1748,6 +1806,7 @@
          :window          format-window
          :partition-by    format-selects
          :order-by        format-order-by
+         :frame           format-frame
          :qualify         format-on-expr
          :limit           format-on-expr
          :offset          (fn [_ x]

--- a/src/honey/sql/helpers.cljc
+++ b/src/honey/sql/helpers.cljc
@@ -928,6 +928,32 @@
   [& args]
   (generic :order-by args))
 
+(defn frame
+  "Accepts a window frame specification, as part of an `:over`
+  expression or a `WINDOW` definition. The arguments are, in order:
+
+  * a frame mode: `:rows`, `:range` or `:groups`,
+  * either a single frame start bound, or `:between` followed by a
+    start bound and an end bound,
+  * an optional frame exclusion: `:exclude-current-row`,
+    `:exclude-group`, `:exclude-ties` or `:exclude-no-others`.
+
+  A bound is either one of the keywords `:unbounded-preceding`,
+  `:current-row` or `:unbounded-following`, or a pair of an offset
+  expression and a direction, `[n :preceding]` or `[n :following]`
+  (the offset may be a parameter or any SQL expression).
+
+  (frame :rows :between :unbounded-preceding :current-row)
+  (frame :range :between [5 :preceding] [10 :following])
+  (frame :groups :current-row :exclude-ties)
+
+  Produces:
+  ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+  RANGE BETWEEN ? PRECEDING AND ? FOLLOWING
+  GROUPS CURRENT ROW EXCLUDE TIES"
+  [& args]
+  (generic :frame args))
+
 (defn limit
   "Specific to some databases (notabley MySQL),
   accepts a single SQL expression:

--- a/test/honey/sql/helpers_test.cljc
+++ b/test/honey/sql/helpers_test.cljc
@@ -12,7 +12,7 @@
                      create-index
                      bulk-collect-into
                      cross-join do-update-set drop-column drop-table
-                     filter from full-join
+                     filter frame from full-join
                      group-by having insert-into replace-into
                      join-by join left-join limit offset on-conflict
                      on-duplicate-key-update
@@ -589,6 +589,35 @@
                " AVG(salary) OVER () AS Average,"
                " MAX(salary) OVER () AS MaxSalary"
                " FROM employee")])))
+
+(deftest window-frame-helper-tests
+  (testing "frame helper builds the :frame clause vector"
+    (is (= {:partition-by [:dept] :order-by [:ts] :frame [:rows :unbounded-preceding]}
+           (-> (partition-by :dept) (order-by :ts) (frame :rows :unbounded-preceding)))))
+  (testing "frame helper threads inside over"
+    (is (= (-> (select [[:over [[:sum :x]
+                                (-> (partition-by :dept)
+                                    (order-by :ts)
+                                    (frame :rows :between :unbounded-preceding :current-row))
+                                :running]]])
+               (from :t)
+               sql/format)
+           [(str "SELECT SUM(x) OVER ("
+                 "PARTITION BY dept ORDER BY ts ASC"
+                 " ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running"
+                 " FROM t")])))
+  (testing "frame helper with offset bounds and exclusion"
+    (is (= (-> (select [[:over [[:sum :x]
+                                (-> (order-by :ts)
+                                    (frame :range :between [5 :preceding] [10 :following] :exclude-ties))
+                                :running]]])
+               (from :t)
+               sql/format)
+           [(str "SELECT SUM(x) OVER ("
+                 "ORDER BY ts ASC"
+                 " RANGE BETWEEN ? PRECEDING AND ? FOLLOWING EXCLUDE TIES) AS running"
+                 " FROM t")
+            5 10]))))
 
 (deftest issue-293-basic-ddl
   (is (= (sql/format {:create-view :metro :select [:*] :from [:cities] :where [:= :metroflag "y"]})

--- a/test/honey/sql_test.cljc
+++ b/test/honey/sql_test.cljc
@@ -1636,6 +1636,75 @@ ORDER BY id = ? DESC
                                     [:<> :-row-hash lag-over]
                                     [:is lag-over nil]]}))))))
 
+(deftest window-frame-tests
+  (let [over (fn [spec opts]
+               (sut/format {:select [[[:over [[:sum :x] spec :w]]]] :from :t} opts))]
+    (testing "single start bound"
+      (is (= ["SELECT SUM(x) OVER (ROWS UNBOUNDED PRECEDING) AS w FROM t"]
+             (over {:frame [:rows :unbounded-preceding]} {}))))
+    (testing "BETWEEN with two special bounds"
+      (is (= ["SELECT SUM(x) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS w FROM t"]
+             (over {:frame [:rows :between :unbounded-preceding :current-row]} {}))))
+    (testing "offset bounds are parameterized left-to-right"
+      (is (= ["SELECT SUM(x) OVER (RANGE BETWEEN ? PRECEDING AND ? FOLLOWING) AS w FROM t" 5 10]
+             (over {:frame [:range :between [5 :preceding] [10 :following]]} {}))))
+    (testing "offset bound honors :inline"
+      (is (= ["SELECT SUM(x) OVER (ROWS 3 PRECEDING) AS w FROM t"]
+             (over {:frame [:rows [3 :preceding]]} {:inline true})))
+      (is (= ["SELECT SUM(x) OVER (ROWS 3 PRECEDING) AS w FROM t"]
+             (over {:frame [:rows [[:inline 3] :preceding]]} {}))))
+    (testing "offset bound may be a named parameter"
+      (is (= ["SELECT SUM(x) OVER (ROWS BETWEEN ? PRECEDING AND CURRENT ROW) AS w FROM t" 7]
+             (over {:frame [:rows :between [[:param :lo] :preceding] :current-row]} {:params {:lo 7}}))))
+    (testing "all three modes"
+      (is (= ["SELECT SUM(x) OVER (ROWS CURRENT ROW) AS w FROM t"]
+             (over {:frame [:rows :current-row]} {})))
+      (is (= ["SELECT SUM(x) OVER (RANGE CURRENT ROW) AS w FROM t"]
+             (over {:frame [:range :current-row]} {})))
+      (is (= ["SELECT SUM(x) OVER (GROUPS CURRENT ROW) AS w FROM t"]
+             (over {:frame [:groups :current-row]} {}))))
+    (testing "all four exclusions"
+      (is (= ["SELECT SUM(x) OVER (ROWS CURRENT ROW EXCLUDE CURRENT ROW) AS w FROM t"]
+             (over {:frame [:rows :current-row :exclude-current-row]} {})))
+      (is (= ["SELECT SUM(x) OVER (ROWS CURRENT ROW EXCLUDE GROUP) AS w FROM t"]
+             (over {:frame [:rows :current-row :exclude-group]} {})))
+      (is (= ["SELECT SUM(x) OVER (ROWS CURRENT ROW EXCLUDE TIES) AS w FROM t"]
+             (over {:frame [:rows :current-row :exclude-ties]} {})))
+      (is (= ["SELECT SUM(x) OVER (ROWS CURRENT ROW EXCLUDE NO OTHERS) AS w FROM t"]
+             (over {:frame [:rows :current-row :exclude-no-others]} {}))))
+    (testing "single offset bound + exclusion (the ambiguity case)"
+      (is (= ["SELECT SUM(x) OVER (ROWS ? PRECEDING EXCLUDE NO OTHERS) AS w FROM t" 3]
+             (over {:frame [:rows [3 :preceding] :exclude-no-others]} {}))))
+    (testing "BETWEEN with exclusion"
+      (is (= ["SELECT SUM(x) OVER (GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING EXCLUDE TIES) AS w FROM t"]
+             (over {:frame [:groups :between :current-row :unbounded-following :exclude-ties]} {}))))
+    (testing "frame renders after PARTITION BY and ORDER BY inside :over"
+      (is (= ["SELECT SUM(x) OVER (PARTITION BY dept ORDER BY ts ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running FROM t"]
+             (sut/format {:select [[[:over [[:sum :x]
+                                            {:partition-by [:dept] :order-by [:ts]
+                                             :frame [:rows :between :unbounded-preceding :current-row]}
+                                            :running]]]]
+                          :from :t}))))
+    (testing "frame inside a named WINDOW definition"
+      (is (= ["SELECT * FROM t WINDOW w AS (PARTITION BY a ORDER BY b ASC RANGE UNBOUNDED PRECEDING)"]
+             (sut/format {:select :* :from :t
+                          :window [:w {:partition-by [:a] :order-by [:b]
+                                       :frame [:range :unbounded-preceding]}]}))))
+    (testing "symbol forms are accepted"
+      (is (= ["SELECT SUM(x) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS w FROM t"]
+             (over {:frame '[rows between unbounded-preceding current-row]} {})))
+      (is (= ["SELECT SUM(x) OVER (RANGE BETWEEN ? PRECEDING AND ? FOLLOWING EXCLUDE TIES) AS w FROM t" 5 10]
+             (over {:frame ['range 'between [5 'preceding] [10 'following] 'exclude-ties]} {}))))
+    (testing "malformed frames throw"
+      (is (thrown-with-msg? ExceptionInfo #"expects 1 bound"
+                            (over {:frame [:rows]} {})))
+      (is (thrown-with-msg? ExceptionInfo #"mode must be one of"
+                            (over {:frame [:foo :current-row]} {})))
+      (is (thrown-with-msg? ExceptionInfo #"expects 2 bounds"
+                            (over {:frame [:rows :between :current-row]} {})))
+      (is (thrown-with-msg? ExceptionInfo #"invalid window frame exclusion"
+                            (over {:frame [:rows :current-row :exclude-foo]} {}))))))
+
 (comment
   ;; partial (incorrect!) workaround for #407:
   (sut/format {:select :f.* :from [[:foo [:f :for :system-time]]] :where [:= :f.id 1]})


### PR DESCRIPTION
## What

Adds window **frame** support to HoneySQL — the `ROWS` / `RANGE` / `GROUPS … PRECEDING/FOLLOWING/CURRENT ROW/EXCLUDE` portion of a window specification — which was previously unsupported. It works inside both `:over` expressions and named `:window` definitions.

This clause is already in successful internal use in our project, where it backs real window-frame queries.

Window frames are ANSI-standard SQL (SQL:2003+) — this is **not** dialect-specific.

## Syntax

A new `:frame` clause (and matching `frame` helper) takes a positional vector in SQL token order:

```
:frame [mode (:between?) start (end) (exclusion?)]
```

- **mode**: `:rows`, `:range` or `:groups`
- **bounds**: `:unbounded-preceding`, `:current-row`, `:unbounded-following`, or an offset pair `[n :preceding]` / `[n :following]`
- **exclusion** (optional, trailing): `:exclude-current-row`, `:exclude-group`, `:exclude-ties`, `:exclude-no-others`

```clojure
;; data DSL
{:select [[[:over [[:sum :salary]
                   {:partition-by [:department]
                    :order-by     [:salary]
                    :frame [:rows :between :unbounded-preceding :current-row]}
                   :running-total]]]]
 :from :employee}
;; => SELECT SUM(salary) OVER (PARTITION BY department ORDER BY salary ASC
;;            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running_total FROM employee

;; offset bounds are expressions, so they parameterize (or inline):
{:frame [:range :between [5 :preceding] [10 :following]]}
;; => RANGE BETWEEN ? PRECEDING AND ? FOLLOWING   params: [5 10]

;; helper form composes by threading, like partition-by / order-by:
(over [[:sum :salary]
       (-> (partition-by :department)
           (order-by :salary)
           (frame :rows :between :unbounded-preceding :current-row))
       :running-total])
```

## Design notes

The syntax leans entirely on existing HoneySQL conventions rather than introducing new machinery:

- **`sql-kw`** already renders multi-word tokens: `:unbounded-preceding` → `UNBOUNDED PRECEDING`, `:current-row` → `CURRENT ROW`, `:exclude-no-others` → `EXCLUDE NO OTHERS` — the same mechanism behind `:select-distinct` / `:nulls-first`.
- **Offset bounds** `[n :preceding]` mirror `order-by`'s `[expr :dir]` pairs and flow through `format-expr`, so they support parameters, `:inline`, named params, and arbitrary expressions for free.
- The clause registers **between `:order-by` and `:limit`** in `default-clause-order`, so it renders in the correct position inside both `:over` (via the `format-dsl` window spec) and `:window` definitions with no changes to either formatter — the same global-registration approach `:partition-by` uses.
- The `:between` keyword is the **sole discriminator** between the single-start and two-bound forms (exact-keyword test, not arity), and exclusions are matched against a **closed set** so a typo errors loudly instead of leaking bad SQL. Malformed frames (bad mode, wrong bound count, unknown exclusion, trailing junk) throw `ex-info`.

## Tests

- `honey.sql-test/window-frame-tests` — format level: all three modes, single/`:between` bounds, offset params + `:inline` + named params, all four exclusions, the single-bound-plus-exclusion ambiguity case, frame inside `:over` and inside `:window`, and malformed-frame errors.
- `honey.sql.helpers-test/window-frame-helper-tests` — helper builds the clause vector and threads through `over`.
- `doc/clause-reference.md` gains a **frame** section; the examples are executed by the doc-block test suite.

Full suite green: JVM `clojure -M:test` (174 tests / 813 assertions), Babashka `bb test:bb` (173 / 794), `bb doc-test` (254 / 444), `bb eastwood` (0 warnings).

---

## Notes for review — two judgment calls

A couple of decisions here are genuine choices rather than the only option, so flagging them explicitly:

1. **Doc placement of the `frame` section.** I put `## frame` in the window cluster (right after `## window, partition-by (and over)`), not in strict `default-clause-order` position (which would be *after* `## order-by`). The reference doc already groups by concept — `## distinct, expr` sits in the same cluster, described as "related to the windowing clauses," despite `:distinct` being far earlier in clause-order — so keeping the window family together reads better. If you'd prefer strict clause-order, it's a one-block move below `## order-by`.

2. **Whether to validate at all.** `format-frame` throws `ex-info` on a bad mode, wrong bound count, or unknown exclusion. This follows the `:join-by` precedent (which validates a join type against an allowed set and throws unconditionally), since a malformed frame vector can't render meaningful SQL. But it's slightly stricter than pure pass-through; if you'd rather emit whatever and let the database reject it, the validation is easy to drop. Happy to go either way.

Verified across the JVM, Babashka **and ClojureScript** suites (the cljs run confirms the `thrown-with-msg? ExceptionInfo` assertions and the `.cljc` code compile and pass under cljs), plus `bb eastwood` (0 warnings) and `bb doc-test`.

