### PR TITLE
[perf] Optimize suspicious?

### DIFF
--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -170,8 +170,13 @@
 (def ^:no-doc ^:dynamic *nest-infix* true)
 
 ;; suspicious entity names:
-(def ^:private suspicious ";,")
-(defn- suspicious? [s] (some #(str/includes? s (str %)) suspicious))
+(def ^:private suspicious (vec ";,"))
+(defn- suspicious? [s]
+  ;; Optimization for JVM runtime - feel free to throw away if the suspicious?
+  ;; check becomes more complicated in the future.
+  (some (fn [ch] #?(:clj (> (.indexOf ^String s (int ch)) -1)
+                    :default (str/includes? s (str ch))))
+        suspicious))
 (defn- suspicious-entity-check [entity]
     (when-not (:allow-suspicious-entities *options*)
       (when (suspicious? entity)


### PR DESCRIPTION
Reclaim some of the efficiency that was lost as `suspicious?` became more complex to address the CVE in 2.7.1392.

The main benefit is avoiding turning characters into strings (which is slow and allocates).

Quick benchmark from #545 shows this:

```
Before:
Time per call: 48.60 us   Alloc per call: 72,360b
Time per call: 48.63 us   Alloc per call: 72,360b
Time per call: 48.72 us   Alloc per call: 72,360b

After:
Time per call: 44.46 us   Alloc per call: 66,136b
Time per call: 44.31 us   Alloc per call: 66,136b
Time per call: 44.32 us   Alloc per call: 66,136b
```