### PR TITLE
[perf] Further optimize suspicious?

### DIFF
--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -31,7 +31,7 @@
   (:require [clojure.string :as str]
             #?(:clj [clojure.template])
             [honey.sql.protocols :as p]
-            [honey.sql.util :refer [str join split-by-separator into*]]))
+            [honey.sql.util :refer [str join split-by-separator into* or-fn]]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -171,12 +171,25 @@
 
 ;; suspicious entity names:
 (def ^:private suspicious (vec ";,"))
-(defn- suspicious? [s]
-  ;; Optimization for JVM runtime - feel free to throw away if the suspicious?
-  ;; check becomes more complicated in the future.
-  (some (fn [ch] #?(:clj (> (.indexOf ^String s (int ch)) -1)
-                    :default (str/includes? s (str ch))))
-        suspicious))
+
+#?(:clj
+   (def suspicious?
+     ;; Optimization for JVM runtime - feel free to throw away if the suspicious?
+     ;; check becomes more complicated in the future.
+     ;; Suitable only for multiple char membership test
+     (transduce
+      (map
+       (fn [ch]
+         (let [ch (int ch)]
+           (fn [s]
+             (> (.indexOf ^String s ch) -1)))))
+      (completing or-fn)
+      (fn [_] false)
+      suspicious))
+   :default
+   (defn- suspicious? [s]
+     (some (fn [ch] (str/includes? s (str ch))) suspicious)))
+
 (defn- suspicious-entity-check [entity]
     (when-not (:allow-suspicious-entities *options*)
       (when (suspicious? entity)

--- a/src/honey/sql/util.cljc
+++ b/src/honey/sql/util.cljc
@@ -107,3 +107,8 @@
        (reduce conj! to' from4)
        (persistent! to'))
      to)))
+
+(defn or-fn
+  [f1 f2]
+  (fn [x]
+    (or (f1 x) (f2 x))))


### PR DESCRIPTION
The existing `suspicious?` still added two performance overheads: iteration and allocation.

Both can be pushed to eval step instead of runtime as long as the suspicious check remains one of simple char membership

Before:
```
44.2 ns  3σ [15.8 72.6]  min 40.4
69.3 ns  3σ [27.8 111]  min 38.5
44.5 ns  3σ [20.0 69.1]  min 37.8
```
After:
```
7.61 ns  3σ [6.96 8.26]  min 6.81
9.68 ns  3σ [8.40 11.0]  min 8.80
8.79 ns  3σ [3.76 13.8]  min 6.63
```

I've been following all perf related PRs and thought I might chime in :)