### PR TITLE
[perf] Rewrite clj alphanumeric check to state machine

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -46,7 +46,7 @@
            :extra-deps  {io.github.cognitect-labs/test-runner
                          {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
            :task (exec 'cognitect.test-runner.api/test)
-           :exec-args {:patterns ["^(?!honey.cache).*-test$"]}}
+           :exec-args {:patterns ["^(?!(honey.cache|honey.sql-alphanumeric)).*-test$"]}}
 
   test:all {:doc "Run all tests for different Clojure versions and ClojureScript"
             :task (binding [*command-line-args* (conj *command-line-args* "all")]

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,8 @@
   {:extra-paths ["test"]
    :extra-deps  {io.github.cognitect-labs/test-runner
                  {:git/tag "v0.5.1" :git/sha "dfb30dd"}
-                 org.clojure/core.cache {:mvn/version "1.2.263"}}
+                 org.clojure/core.cache {:mvn/version "1.2.263"}
+                 com.gfredericks/test.chuck {:mvn/version "0.2.15"}}
    :exec-fn     cognitect.test-runner.api/test}
   :runner
   {:main-opts   ["-m" "cognitect.test-runner"]}

--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -310,6 +310,79 @@
 
 (def ^:private ^:dynamic *drop-ns* false)
 
+#?(:clj
+   (defn alphanumeric?
+     "Translation of the prior alphanumeric regex to state machine.
+  Basic regex for entities that do not need quoting.
+   Either:
+   * the whole entity is numeric (with optional underscores), or
+   * the first character is alphabetic (or underscore) and the rest is
+     alphanumeric (or underscore).
+  `^(?:[0-9_]+|[A-Za-z_][A-Za-z0-9_]*)$`"
+     [^String s]
+     (let [leading-underscore 1
+           numeric 2
+           identifier 3
+           dead 4
+           n (long (.length s))]
+       (loop [i (unchecked-long 0)
+              state (unchecked-long 0)]
+         (if (or (= state dead) (>= i n))
+           (or (= state leading-underscore) (= state numeric) (= state identifier))
+           (let [c (.charAt s (unchecked-int i))
+                 c (unchecked-long (unchecked-int c))
+                 ni (unchecked-inc i)]
+             (case state
+               0
+               (cond
+                 (or (and (>= c 65) (<= c 90))
+                     (and (>= c 97) (<= c 122)))
+                 (recur ni identifier)
+
+                 (and (>= c 48) (<= c 57))
+                 (recur ni numeric)
+
+                 (= c 95)
+                 (recur ni leading-underscore)
+
+                 :else
+                 (recur ni dead))
+
+               1
+               (cond
+                 (or (and (>= c 65) (<= c 90))
+                     (and (>= c 97) (<= c 122)))
+                 (recur ni identifier)
+
+                 (and (>= c 48) (<= c 57))
+                 (recur ni identifier)   ;; not numeric
+
+                 (= c 95)
+                 (recur ni leading-underscore)
+
+                 :else
+                 (recur ni dead))
+
+               2
+               (if (or (and (>= c 48) (<= c 57))
+                       (= c 95))
+                 (recur ni numeric)
+                 (recur ni dead))
+
+               3
+               (if (or (and (>= c 65) (<= c 90))
+                       (and (>= c 97) (<= c 122))
+                       (and (>= c 48) (<= c 57))
+                       (= c 95))
+                 (recur ni identifier)
+                 (recur ni dead))
+
+               (recur ni dead)))))))
+   :default
+   (defn alphanumeric?
+     [s]
+     (boolean (re-find alphanumeric s))))
+
 (defn format-entity
   "Given a simple SQL entity (a keyword or symbol -- or string),
   return the equivalent SQL fragment (as a string -- no parameters).
@@ -338,7 +411,7 @@
                            (fn opt-quote [part]
                              (cond (some-> quoted-always (re-find part))
                                    (dialect-q part)
-                                   (re-find alphanumeric part)
+                                   (alphanumeric? part)
                                    part
                                    :else
                                    (dialect-q part)))

--- a/test/honey/sql_alphanumeric_test.clj
+++ b/test/honey/sql_alphanumeric_test.clj
@@ -1,0 +1,50 @@
+(ns honey.sql-alphanumeric-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [is]]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [com.gfredericks.test.chuck.generators :as gen']
+            [honey.sql :as sut]))
+
+(def alphanumeric @#'sut/alphanumeric)
+
+(defn alphanumeric?
+  [s]
+  (boolean (re-find alphanumeric s)))
+
+(defspec matches-token-spec-for-matching 1000
+  (prop/for-all [s (gen'/string-from-regex
+                    (let [s (str alphanumeric)] ; remove anchors
+                      (re-pattern (subs s 1 (dec (count s))))))]
+                (is
+                 (=
+                  (sut/alphanumeric? s)
+                  (alphanumeric? s)))))
+(def pattern
+  (re-pattern
+   (str
+    "["
+    "\r"
+    "\n"
+    (char 133) ; ever heard about NE(xt)L(ine)?
+    "]+$")))
+
+(defn strip-trailing-newlines
+  [s]
+  (str/replace s pattern ""))
+
+(defspec matches-token-spec-for-random-string 1000
+  (prop/for-all [s (gen/fmap strip-trailing-newlines gen/string)]
+                (is
+                 (=
+                  (sut/alphanumeric? s)
+                  (alphanumeric? s)))))
+
+(comment
+  (def s "__abcdefghijklmnop")
+  (dotimes [_ 10]
+    (time
+     (dotimes [_ 1e6]
+       #_(sut/alphanumeric? s)
+       (alphanumeric? s)))))


### PR DESCRIPTION
The current alphanumeric regex is simple enough to translate to a state
machine.

The hand rolled state machine implementation is about 10x faster, see
added RCF added at the test file.

Added property based tests to guard against regression in the rewrite.

Tests added only for clj, requires test-chuck which bb can't run, so
added another alias which is appended for non bb non cljs tests