### PR TITLE
[perf] Check for suspicious entries first, then if they are allowed

### DIFF
--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -191,10 +191,10 @@
      (some (fn [ch] (str/includes? s (str ch))) suspicious)))
 
 (defn- suspicious-entity-check [entity]
+  (when (suspicious? entity)
     (when-not (:allow-suspicious-entities *options*)
-      (when (suspicious? entity)
-        (throw (ex-info (str "suspicious character found in entity: " entity)
-                        {:disallowed suspicious})))))
+      (throw (ex-info (str "suspicious character found in entity: " entity)
+                      {:disallowed suspicious})))))
 
 (comment
   (some #(str/includes? "foo,bar" (str %)) suspicious)


### PR DESCRIPTION
Since `:allow-suspicious-entities` defaults to false, and will rarely be enabled, almost every caller pays the extra cost of dereferencing a dynamic variable. And because most entities are not suspicious, then this dereference will not be needed at all most of the time.

In my syntethic benchmark, I'm getting a 3% improvement on a flamegraph. On the benchmark results itself, the improvement is harder to spot (variance is high), but I think it is still worth doing.