### PR TITLE
Update jolt dependency SHA to v0.0.2 in deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -34,7 +34,7 @@
   :jolt
   {:extra-deps {io.github.jolt-lang/time
                 {:git/url "https://github.com/jolt-lang/time.git"
-                 :git/sha "26ae332cbe4b6515ae2386c50ed0ae34cafa483a"}}}
+                 :git/sha "4bd08de1d8cb94aa19a4091e4e2523eca4a9a4c9"}}}
 
   :gen-doc-tests {:replace-paths ["build"]
                   :extra-deps {babashka/fs {:mvn/version "0.5.33"}


### PR DESCRIPTION
Running tests against Honeysql exposed a bug in the time library, this bumps it up to the latest version with the fix.