### PR TITLE
pin GHA deps by commit SHA

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -9,20 +9,20 @@ jobs:
   build-and-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'
       - name: Setup Clojure and Babashka
-        uses: DeLaGuardo/setup-clojure@master
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           cli: '1.12.5.1654'
           bb: latest
       - name: Cache All The Things
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/test-and-snapshot.yml
+++ b/.github/workflows/test-and-snapshot.yml
@@ -9,18 +9,18 @@ jobs:
   build-and-snapshot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'
       - name: Setup Clojure and Babashka
-        uses: DeLaGuardo/setup-clojure@master
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           cli: '1.12.5.1654'
           bb: latest
       - name: Cache All The Things
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.m2/repository
@@ -41,18 +41,18 @@ jobs:
       matrix:
         java: [ '21', '25' ]
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Setup Clojure and Babashka
-        uses: DeLaGuardo/setup-clojure@master
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           cli: '1.12.5.1654'
           bb: latest
       - name: Cache All The Things
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,18 +9,18 @@ jobs:
       matrix:
         java: [ '17', '21', '25' ]
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Setup Clojure and Babashka
-        uses: DeLaGuardo/setup-clojure@master
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           cli: '1.12.5.1654'
           bb: latest
       - name: Cache All The Things
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.m2/repository


### PR DESCRIPTION
Hi Sean, small drive-by contribution: this pins the four actions used across the three workflows to their commit shas, versions kept as comments.

The one that motivated it is `DeLaGuardo/setup-clojure@master`: a branch ref, so every run executes whatever master points to at that moment, including in `test-and-release.yml` which runs with your Clojars deploy secrets. A compromised or hijacked upstream re-points the ref and your next release build runs their code. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066). The pin is the current 13.6.1 release commit, which is exactly where master sits today, so nothing changes behavior.

The `actions/*` ones are lower risk but pinned too while at it: checkout `3d3c42e` is v7.0.1, setup-java `03ad4de` is v5.6.0, cache `55cc834` is v6.1.0. All shas resolved from the upstream repos and cross checked against their tags. No logic changes, only the `uses:` lines.

Found with the Plumber CLI (https://github.com/getplumber/plumber), verified on develop. I can also open a PR which will adds it to CI so this does not quietly drift back, that one is a bonus, this PR stands on its own.